### PR TITLE
$split: return undefined for non-string input

### DIFF
--- a/functions/string_funcs.go
+++ b/functions/string_funcs.go
@@ -424,7 +424,7 @@ func fnSplit(args []any, _ any) (any, error) {
 	}
 	s, ok := args[0].(string)
 	if !ok {
-		return nil, &evaluator.JSONataError{Code: "T0410", Message: "$split: argument 1 must be a string"}
+		return nil, nil
 	}
 	if len(args) < 2 {
 		return nil, &evaluator.JSONataError{Code: "D3006", Message: "$split: requires at least 2 arguments"}

--- a/testdata/groups/function-split/case016.json
+++ b/testdata/groups/function-split/case016.json
@@ -2,5 +2,5 @@
     "expr": "$split(12345, 3)",
     "dataset": null,
     "bindings": {},
-    "code": "T0410"
+    "undefinedResult": true
 }

--- a/testdata/groups/function-split/case017.json
+++ b/testdata/groups/function-split/case017.json
@@ -2,5 +2,5 @@
     "expr": "$split(12345)",
     "dataset": null,
     "bindings": {},
-    "code": "T0410"
+    "undefinedResult": true
 }


### PR DESCRIPTION
## Summary

- `$split` threw a hard `T0410` error when arg1 was a non-string type (number, boolean), while the reference jsonata npm package returns `undefined`
- This caused evaluation mismatches when gnata is used as a drop-in JSONata replacement
- Fix: return `nil` (undefined) for non-string input, matching jsonata npm behavior

## Changes

- `functions/string_funcs.go`: Return `nil` instead of `T0410` error for non-string first argument
- `testdata/groups/function-split/case016.json`: Expect `undefinedResult` instead of `T0410`
- `testdata/groups/function-split/case017.json`: Expect `undefinedResult` instead of `T0410`

## Test plan

- [x] All 19 `function-split` test cases pass
- [x] `go build ./...` compiles cleanly


Made with [Cursor](https://cursor.com)