### PR TITLE
Add EvalMap for pre-decoded JSON input

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,9 @@ for i, result := range results {
         handleMatch(indices[i], result)
     }
 }
+
+// Alternative: pre-decoded map input (avoids re-serialization)
+results, _ = se.EvalMap(ctx, fieldMap, schemaKey, indices)
 ```
 
 ### Custom Function Registration
@@ -156,6 +159,7 @@ Hot Path (millions/day, lock-free)
 - **Schema-keyed caching** — the `GroupPlan` (merged paths, expression groupings, selective unmarshal targets) is computed once per schema key and reused immutably.
 - **Lock-free reads** — `BoundedCache` publishes an `atomic.Pointer` snapshot on every write; reads scan the snapshot without acquiring a lock. Writes are serialised by a mutex.
 - **Selective unmarshal** — full-path expressions unmarshal only the subtrees they need (e.g., just the `items` array from a 10KB event), not the entire document.
+- **Pre-decoded map input** — `EvalMap` accepts `map[string]json.RawMessage` directly, skipping full-document serialization when the caller already has individually-encoded fields. Fast paths resolve top-level keys via O(1) map lookup.
 - **Dynamic mutation** — `Replace`, `Remove`, and `Reset` methods allow modifying registered expressions at runtime with automatic cache invalidation.
 - **Observability** — implement `MetricsHook` to receive per-evaluation callbacks for cache hits/misses, eval latency, fast-path usage, and errors.
 
@@ -417,7 +421,7 @@ All standard regex features (character classes, quantifiers, alternation, groupi
 ```
 gnata/
 ├── gnata.go                     # Public API: Compile, Eval, EvalBytes, EvalWithVars, CustomFunc
-├── stream.go                    # StreamEvaluator, GroupPlan, EvalMany, MetricsHook
+├── stream.go                    # StreamEvaluator, GroupPlan, EvalMany, EvalMap, MetricsHook
 ├── bounded_cache.go             # Lock-free FIFO ring-buffer plan cache
 ├── deep_equal.go                # JSONata-compatible deep equality
 ├── internal/

--- a/func_fast.go
+++ b/func_fast.go
@@ -72,8 +72,8 @@ var funcFastHandlers = map[parser.FuncFastKind]funcFastHandler{
 	parser.FuncFastAverage:   evalFuncAverage,
 }
 
-func evalFuncBytes(f *parser.FuncFastPath, data json.RawMessage) (result any, handled bool, err error) {
-	r := gjson.GetBytes(data, f.Path)
+func evalFunc(f *parser.FuncFastPath, data json.RawMessage, mapData map[string]json.RawMessage) (result any, handled bool, err error) {
+	r := resolveGjsonPath(data, mapData, f.Path)
 	if !r.Exists() {
 		// Fall through to full evaluator — gjson doesn't auto-map through
 		// arrays, so the path might still resolve via the AST walker.

--- a/gnata.go
+++ b/gnata.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"strings"
 
 	"github.com/recolabs/gnata/functions"
 	"github.com/recolabs/gnata/internal/evaluator"
@@ -206,12 +207,12 @@ func (e *Expression) EvalBytes(ctx context.Context, data json.RawMessage) (resul
 		// which handles auto-mapping through arrays correctly.
 	}
 	if e.cmpFast != nil {
-		if res, handled, evalErr := evalComparisonBytes(e.cmpFast, data); handled || evalErr != nil {
+		if res, handled, evalErr := evalComparison(e.cmpFast, data, nil); handled || evalErr != nil {
 			return res, evalErr
 		}
 	}
 	if e.funcFast != nil {
-		if res, handled, evalErr := evalFuncBytes(e.funcFast, data); handled || evalErr != nil {
+		if res, handled, evalErr := evalFunc(e.funcFast, data, nil); handled || evalErr != nil {
 			return res, evalErr
 		}
 	}
@@ -222,14 +223,44 @@ func (e *Expression) EvalBytes(ctx context.Context, data json.RawMessage) (resul
 	return e.Eval(ctx, v)
 }
 
-// evalComparisonBytes evaluates a pre-compiled comparison fast path against raw JSON bytes.
-// Returns (result, true, nil) on success. Returns (nil, false, nil) when the expression
-// cannot safely short-circuit (e.g. the LHS is a JSON array that requires auto-mapping),
-// signalling the caller to fall back to full evaluation.
+// resolveGjsonPath resolves a gjson path from either raw bytes or a pre-decoded map.
+// When data is available (EvalMany), it delegates to gjson.GetBytes on the full blob.
+// When mapData is available (EvalMap), it does an O(1) map lookup for the top-level
+// key, then uses gjson on the nested value bytes — skipping sibling keys entirely.
+// Paths containing gjson special characters fall through to return an empty result,
+// letting the caller fall back to full AST evaluation.
+func resolveGjsonPath(data json.RawMessage, mapData map[string]json.RawMessage, path string) gjson.Result {
+	if data != nil {
+		return gjson.GetBytes(data, path)
+	}
+	if mapData == nil {
+		return gjson.Result{}
+	}
+	if strings.ContainsAny(path, `\#*?@`) {
+		return gjson.Result{}
+	}
+	key, rest, hasDot := strings.Cut(path, ".")
+	raw, ok := mapData[key]
+	if !ok {
+		return gjson.Result{}
+	}
+	if !hasDot {
+		return gjson.ParseBytes(raw)
+	}
+	return gjson.GetBytes(raw, rest)
+}
+
+// evalComparison evaluates a pre-compiled comparison fast path against raw JSON
+// bytes or a pre-decoded map. Returns (result, true, nil) on success. Returns
+// (nil, false, nil) when the expression cannot safely short-circuit (e.g. the
+// LHS is a JSON array that requires auto-mapping), signalling the caller to
+// fall back to full evaluation.
 //
 //nolint:unparam // err is part of the funcFastHandler contract; always nil for now
-func evalComparisonBytes(c *parser.ComparisonFastPath, data json.RawMessage) (result any, handled bool, err error) {
-	lhs := gjson.GetBytes(data, c.LHSPath)
+func evalComparison(
+	c *parser.ComparisonFastPath, data json.RawMessage, mapData map[string]json.RawMessage,
+) (result any, handled bool, err error) {
+	lhs := resolveGjsonPath(data, mapData, c.LHSPath)
 	if !lhs.Exists() {
 		// gjson couldn't resolve the path. This could be because the path is
 		// truly undefined OR because an intermediate element is a JSON array

--- a/internal/evaluator/ordered_map.go
+++ b/internal/evaluator/ordered_map.go
@@ -3,6 +3,7 @@ package evaluator
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"maps"
 	"slices"
 )
@@ -145,6 +146,21 @@ func DecodeJSON(b json.RawMessage) (any, error) {
 	dec := json.NewDecoder(bytes.NewReader(b))
 	dec.UseNumber()
 	return decodeValue(dec)
+}
+
+// DecodeRawMap converts a map of field names to raw JSON values into an
+// *OrderedMap by decoding each value individually via DecodeJSON. Objects
+// in the values preserve key insertion order, consistent with DecodeJSON.
+func DecodeRawMap(m map[string]json.RawMessage) (*OrderedMap, error) {
+	om := NewOrderedMapWithCapacity(len(m))
+	for key, raw := range m {
+		val, err := DecodeJSON(raw)
+		if err != nil {
+			return nil, fmt.Errorf("decode key %q: %w", key, err)
+		}
+		om.Set(key, val)
+	}
+	return om, nil
 }
 
 func decodeValue(dec *json.Decoder) (any, error) {

--- a/stream.go
+++ b/stream.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/recolabs/gnata/internal/evaluator"
 	"github.com/recolabs/gnata/internal/parser"
-	"github.com/tidwall/gjson"
 )
 
 // StreamEvaluator manages compiled expressions for high-throughput streaming evaluation.
@@ -216,6 +215,25 @@ func (se *StreamEvaluator) Reset() {
 // Returns results[i] = evaluation of expressions[exprIndices[i]], or nil for undefined.
 func (se *StreamEvaluator) EvalMany(
 	ctx context.Context, data json.RawMessage, schemaKey string, exprIndices []int,
+) ([]any, error) {
+	return se.evalInternal(ctx, data, nil, nil, schemaKey, exprIndices)
+}
+
+// EvalMap evaluates the specified expressions against a map of raw JSON values.
+//   - data: map of field names to raw JSON-encoded values (decoded individually).
+//   - schemaKey: external key identifying the event schema. On first encounter, builds
+//     and caches a GroupPlan. Subsequent calls are lock-free. Pass "" to disable caching.
+//   - exprIndices: which compiled expressions to evaluate.
+//
+// Returns results[i] = evaluation of expressions[exprIndices[i]], or nil for undefined.
+func (se *StreamEvaluator) EvalMap(
+	ctx context.Context, data map[string]json.RawMessage, schemaKey string, exprIndices []int,
+) ([]any, error) {
+	return se.evalInternal(ctx, nil, nil, data, schemaKey, exprIndices)
+}
+
+func (se *StreamEvaluator) evalInternal(
+	ctx context.Context, data json.RawMessage, preparsed any, mapData map[string]json.RawMessage, schemaKey string, exprIndices []int,
 ) (results []any, err error) {
 	defer recoverEvalPanic(&err)
 	if len(exprIndices) == 0 {
@@ -247,7 +265,7 @@ func (se *StreamEvaluator) EvalMany(
 	}
 
 	results = make([]any, len(exprIndices))
-	batch := evalBatch{se: se, plan: plan, data: data}
+	batch := evalBatch{se: se, plan: plan, data: data, mapData: mapData, parsed: preparsed, parseAttempted: preparsed != nil}
 	for i, idx := range exprIndices {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -275,6 +293,7 @@ type evalBatch struct {
 	se             *StreamEvaluator
 	plan           *GroupPlan
 	data           json.RawMessage
+	mapData        map[string]json.RawMessage
 	parsed         any
 	parsedErr      error
 	parseAttempted bool
@@ -300,18 +319,17 @@ func (b *evalBatch) evalSingleExpr(ctx context.Context, i, idx int, expr *Expres
 // or (nil, true, err) on error.
 func (b *evalBatch) tryFastPaths(i, idx int, start time.Time) (result any, done bool, err error) {
 	if b.plan != nil && i < len(b.plan.ExprFastPath) && b.plan.ExprFastPath[i] && b.plan.FastPaths[i] != "" {
-		r := gjson.GetBytes(b.data, b.plan.FastPaths[i])
+		r := resolveGjsonPath(b.data, b.mapData, b.plan.FastPaths[i])
 		if r.Exists() {
 			if b.se.metrics != nil {
 				b.se.metrics.OnEval(idx, true, time.Since(start), nil)
 			}
 			return gjsonValueToAny(&r), true, nil
 		}
-		// gjson miss — fall through to full evaluator (handles array auto-mapping)
 	}
 
 	if b.plan != nil && i < len(b.plan.CmpFast) && b.plan.CmpFast[i] != nil {
-		if result, handled, err := evalComparisonBytes(b.plan.CmpFast[i], b.data); err != nil {
+		if result, handled, err := evalComparison(b.plan.CmpFast[i], b.data, b.mapData); err != nil {
 			if b.se.metrics != nil {
 				b.se.metrics.OnEval(idx, true, time.Since(start), err)
 			}
@@ -325,7 +343,7 @@ func (b *evalBatch) tryFastPaths(i, idx int, start time.Time) (result any, done 
 	}
 
 	if b.plan != nil && i < len(b.plan.FuncFast) && b.plan.FuncFast[i] != nil {
-		if result, handled, err := evalFuncBytes(b.plan.FuncFast[i], b.data); err != nil {
+		if result, handled, err := evalFunc(b.plan.FuncFast[i], b.data, b.mapData); err != nil {
 			if b.se.metrics != nil {
 				b.se.metrics.OnEval(idx, true, time.Since(start), err)
 			}
@@ -345,7 +363,11 @@ func (b *evalBatch) tryFastPaths(i, idx int, start time.Time) (result any, done 
 func (b *evalBatch) fullEval(ctx context.Context, idx int, expr *Expression, start time.Time) (any, error) {
 	if !b.parseAttempted {
 		b.parseAttempted = true
-		b.parsed, b.parsedErr = evaluator.DecodeJSON(b.data)
+		if len(b.mapData) > 0 {
+			b.parsed, b.parsedErr = evaluator.DecodeRawMap(b.mapData)
+		} else if len(b.data) > 0 {
+			b.parsed, b.parsedErr = evaluator.DecodeJSON(b.data)
+		}
 	}
 	if b.parsedErr != nil {
 		return nil, b.parsedErr

--- a/stream_test.go
+++ b/stream_test.go
@@ -387,6 +387,165 @@ func (h *testMetricsHook) OnCacheHit(_ string)  { h.hits++ }
 func (h *testMetricsHook) OnCacheMiss(_ string) { h.misses++ }
 func (h *testMetricsHook) OnEviction()          { h.evictions++ }
 
+// TestStreamEvaluator_EvalMap verifies that EvalMap produces identical results
+// to EvalMany for the same data and expressions.
+func TestStreamEvaluator_EvalMap(t *testing.T) {
+	rawData := json.RawMessage(streamTestData)
+
+	var dataMap map[string]json.RawMessage
+	if err := json.Unmarshal(rawData, &dataMap); err != nil {
+		t.Fatalf("unmarshal to map: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{"path lookup", `data.action`, "grant-access"},
+		{"comparison", `data.user_type = 2`, true},
+		{"boolean field", `metadata.is_admin`, true},
+		{"greater than", `data.user_type > 1`, true},
+		{"nested path", `data.user_type`, float64(2)},
+		{"and expression", `data.user_type = 2 and metadata.is_admin = true`, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			se := gnata.NewStreamEvaluator(nil)
+			idx, err := se.Compile(tc.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", tc.expr, err)
+			}
+
+			evalManyResult, err := se.EvalMany(context.Background(), rawData, "", []int{idx})
+			if err != nil {
+				t.Fatalf("EvalMany: %v", err)
+			}
+
+			evalMapResult, err := se.EvalMap(context.Background(), dataMap, "", []int{idx})
+			if err != nil {
+				t.Fatalf("EvalMap: %v", err)
+			}
+
+			if !gnata.DeepEqual(evalManyResult[0], evalMapResult[0]) {
+				t.Errorf("EvalMany=%v (%T), EvalMap=%v (%T)",
+					evalManyResult[0], evalManyResult[0],
+					evalMapResult[0], evalMapResult[0])
+			}
+			if !gnata.DeepEqual(evalMapResult[0], tc.want) {
+				t.Errorf("want %v (%T), got %v (%T)",
+					tc.want, tc.want, evalMapResult[0], evalMapResult[0])
+			}
+		})
+	}
+}
+
+// TestStreamEvaluator_EvalMap_MultipleExprs verifies that EvalMap evaluates
+// multiple expressions against the same pre-parsed data.
+func TestStreamEvaluator_EvalMap_MultipleExprs(t *testing.T) {
+	var dataMap map[string]json.RawMessage
+	if err := json.Unmarshal(json.RawMessage(streamTestData), &dataMap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	se := gnata.NewStreamEvaluator(nil)
+	idx0, _ := se.Compile(`data.action`)
+	idx1, _ := se.Compile(`data.user_type = 2`)
+	idx2, _ := se.Compile(`metadata.is_admin`)
+
+	results, err := se.EvalMap(context.Background(), dataMap, "schema", []int{idx0, idx1, idx2})
+	if err != nil {
+		t.Fatalf("EvalMap: %v", err)
+	}
+
+	if results[0] != "grant-access" {
+		t.Errorf("result[0]: want grant-access, got %v", results[0])
+	}
+	if results[1] != true {
+		t.Errorf("result[1]: want true, got %v", results[1])
+	}
+	if results[2] != true {
+		t.Errorf("result[2]: want true, got %v", results[2])
+	}
+}
+
+// TestStreamEvaluator_EvalMap_NilAndEmpty verifies edge cases.
+func TestStreamEvaluator_EvalMap_NilAndEmpty(t *testing.T) {
+	se := gnata.NewStreamEvaluator(nil)
+	idx, _ := se.Compile(`foo`)
+
+	results, err := se.EvalMap(context.Background(), nil, "", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalMap(nil): %v", err)
+	}
+	if results[0] != nil {
+		t.Errorf("nil map: want nil result, got %v", results[0])
+	}
+
+	results, err = se.EvalMap(context.Background(), map[string]json.RawMessage{}, "", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalMap(empty): %v", err)
+	}
+	if results[0] != nil {
+		t.Errorf("empty map: want nil result, got %v", results[0])
+	}
+
+	results, err = se.EvalMap(context.Background(), map[string]json.RawMessage{}, "", nil)
+	if err != nil {
+		t.Fatalf("EvalMap(no indices): %v", err)
+	}
+	if results != nil {
+		t.Errorf("no indices: want nil results, got %v", results)
+	}
+}
+
+// TestStreamEvaluator_EvalMap_FastPaths verifies that EvalMap takes the same
+// fast paths (pure path, comparison, function) as EvalMany, using MetricsHook
+// to confirm fastPath=true.
+func TestStreamEvaluator_EvalMap_FastPaths(t *testing.T) {
+	var dataMap map[string]json.RawMessage
+	if err := json.Unmarshal(json.RawMessage(streamTestData), &dataMap); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{"pure path", `data.action`, "grant-access"},
+		{"comparison", `data.user_type = 2`, true},
+		{"function $exists", `$exists(data.action)`, true},
+		{"nested path", `data.user_type`, float64(2)},
+		{"missing top-level key", `nonexistent.field`, nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hook := &testMetricsHook{}
+			se := gnata.NewStreamEvaluator(nil, gnata.WithMetricsHook(hook))
+			idx, err := se.Compile(tc.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", tc.expr, err)
+			}
+
+			results, err := se.EvalMap(context.Background(), dataMap, "s", []int{idx})
+			if err != nil {
+				t.Fatalf("EvalMap: %v", err)
+			}
+
+			if !gnata.DeepEqual(results[0], tc.want) {
+				t.Errorf("want %v (%T), got %v (%T)", tc.want, tc.want, results[0], results[0])
+			}
+
+			if tc.want != nil && hook.fastPaths == 0 {
+				t.Errorf("expected fast path for %q but MetricsHook reported 0 fast paths", tc.expr)
+			}
+		})
+	}
+}
+
 // TestStreamEvaluator_ConcurrentSafety exercises concurrent Add / Compile calls
 // interleaved with EvalMany to surface data races. Run with -race.
 func TestStreamEvaluator_ConcurrentSafety(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `StreamEvaluator.EvalMap` that accepts `map[string]json.RawMessage` directly, avoiding the need to serialize data to `[]byte` before evaluation. This is useful when the caller already has individually-encoded JSON fields (e.g. from a columnar store or message envelope).
- Internally, `DecodeRawMap` converts each value individually via `DecodeJSON` into an `*OrderedMap`, then delegates to the shared `evalInternal` method (refactored out of `EvalMany`).
- Fast paths (pure path, comparison, function) work with the map input via a new `resolveGjsonPath` helper that does an O(1) map lookup for the top-level key, then uses gjson on the nested value bytes.

## Changes

- **`internal/evaluator/ordered_map.go`** — Add `DecodeRawMap` for converting `map[string]json.RawMessage` to `*OrderedMap`
- **`stream.go`** — Refactor `EvalMany` into `evalInternal` + thin `EvalMany` wrapper; add `EvalMap` with `schemaKey` support for GroupPlan caching
- **`gnata.go`** — Add `resolveGjsonPath` for dual raw-bytes / map resolution; generalize `evalComparisonBytes` → `evalComparison` and `evalFuncBytes` → `evalFunc` to accept either input form
- **`func_fast.go`** — Update function fast-path entry point to use `resolveGjsonPath`
- **`stream_test.go`** — Add tests for EvalMap: parity with EvalMany, multiple expressions, nil/empty edge cases, fast-path verification via MetricsHook

## Test plan

- [x] All existing tests pass (1,778 test cases, 0 failures)
- [x] New `TestStreamEvaluator_EvalMap` — verifies parity with EvalMany across path lookups, comparisons, boolean fields, numeric comparisons, and compound expressions
- [x] New `TestStreamEvaluator_EvalMap_MultipleExprs` — verifies batch evaluation of multiple expressions
- [x] New `TestStreamEvaluator_EvalMap_NilAndEmpty` — verifies nil map, empty map, and empty indices edge cases
- [x] New `TestStreamEvaluator_EvalMap_FastPaths` — verifies fast paths are taken via MetricsHook for pure path, comparison, and function expressions