### PR TITLE
Fix singleton unwrapping for $each, $spread, and $match

### DIFF
--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -495,6 +495,79 @@ func TestRegressionExpr(t *testing.T) {
 	}
 }
 
+// TestSingletonUnwrapEdgeCases covers scenarios the JSON suite cannot:
+// error expectations and chain operator (~>) paths.
+func TestSingletonUnwrapEdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		expr      string
+		data      string
+		want      any
+		wantError bool
+	}{
+		{
+			name: "join_nested_each_single_key_errors",
+			expr: `$join($each({"x": {"p": "hi", "q": "lo"}},` +
+				` function($obj, $name) { $each($obj,` +
+				` function($v, $k) { $name & "." & $k & "=" & $v }) })[], ', ')`,
+			data:      `{}`,
+			wantError: true,
+		},
+		{
+			name: "chain_each_single_key",
+			expr: `{"a": 1} ~> $each(function($v, $k) { $k })`,
+			data: `{}`,
+			want: "a",
+		},
+		{
+			name: "chain_spread_single_key",
+			expr: `{"a": 1} ~> $spread()`,
+			data: `{}`,
+			want: map[string]any{"a": float64(1)},
+		},
+		{
+			name: "chain_bare_spread_single_key",
+			expr: `{"a": 1} ~> $spread`,
+			data: `{}`,
+			want: map[string]any{"a": float64(1)},
+		},
+		{
+			name: "composition_spread_merge",
+			expr: `($spread ~> $merge)({"a": 1, "b": 2})`,
+			data: `{}`,
+			want: map[string]any{"a": float64(1), "b": float64(2)},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var data any
+			if err := json.Unmarshal([]byte(tt.data), &data); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+			e, err := gnata.Compile(tt.expr)
+			if err != nil {
+				t.Fatalf("compile %q: %v", tt.expr, err)
+			}
+			result, err := e.Eval(context.Background(), data)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got %v", result)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("eval %q: %v", tt.expr, err)
+			}
+			if tt.want != nil && !gnata.DeepEqual(result, tt.want) {
+				got, _ := json.Marshal(result)
+				want, _ := json.Marshal(tt.want)
+				t.Fatalf("got %s, want %s", got, want)
+			}
+		})
+	}
+}
+
 // TestRegressionBytes covers regressions requiring direct EvalBytes
 // access (e.g. large integers that exceed float64 precision).
 func TestRegressionBytes(t *testing.T) {

--- a/functions/object_funcs.go
+++ b/functions/object_funcs.go
@@ -113,7 +113,7 @@ func fnSpread(args []any, _ any) (any, error) {
 		return result
 	}
 	if evaluator.IsMap(args[0]) {
-		return spreadOne(args[0]), nil
+		return &evaluator.Sequence{Values: spreadOne(args[0])}, nil
 	}
 	if arr, ok := args[0].([]any); ok {
 		var result []any
@@ -241,7 +241,7 @@ func makeFnEach(evalFn EvalFn) evaluator.EnvAwareBuiltin {
 		}
 
 		keys := evaluator.MapKeys(objVal)
-		result := make([]any, 0, len(keys))
+		seq := evaluator.CreateSequence()
 		for _, ks := range keys {
 			val, _ := evaluator.MapGet(objVal, ks)
 			res, err := evalFn(fn, []any{val, ks}, focus, env)
@@ -249,10 +249,10 @@ func makeFnEach(evalFn EvalFn) evaluator.EnvAwareBuiltin {
 				return nil, err
 			}
 			if res != nil {
-				result = append(result, res)
+				seq.Values = append(seq.Values, res)
 			}
 		}
-		return result, nil
+		return seq, nil
 	}
 }
 

--- a/functions/string_match_replace.go
+++ b/functions/string_match_replace.go
@@ -73,11 +73,15 @@ func makeFnMatch(evalFn EvalFn) evaluator.EnvAwareBuiltin {
 				return nil, &evaluator.JSONataError{Code: "D3137", Message: fmt.Sprintf("regex error: %v", matchErr)}
 			}
 		}
-		if len(result) == 0 {
-			return nil, nil
-		}
-		return result, nil
+		return matchResultSeq(result), nil
 	}
+}
+
+func matchResultSeq(result []any) any {
+	if len(result) == 0 {
+		return nil
+	}
+	return &evaluator.Sequence{Values: result}
 }
 
 func matchWithCustomMatcher(s string, matcherFn any, limit int, evalFn EvalFn, env *evaluator.Environment) (any, error) {
@@ -119,10 +123,7 @@ func matchWithCustomMatcher(s string, matcherFn any, limit int, evalFn EvalFn, e
 		}
 	}
 
-	if len(result) == 0 {
-		return nil, nil
-	}
-	return result, nil
+	return matchResultSeq(result), nil
 }
 
 // ── $replace ──────────────────────────────────────────────────────────────────

--- a/internal/evaluator/eval_chain.go
+++ b/internal/evaluator/eval_chain.go
@@ -38,20 +38,7 @@ func evalChain(right *parser.Node, piped, input any, env *Environment) (any, err
 		if err != nil {
 			return nil, err
 		}
-		if right.KeepArray {
-			if seq, ok := result.(*Sequence); ok {
-				result = CollapseSequence(seq)
-			}
-			switch result.(type) {
-			case []any:
-				return result, nil
-			case nil:
-				return nil, nil
-			default:
-				return []any{result}, nil
-			}
-		}
-		return result, nil
+		return CollapseAndKeep(result, right.KeepArray), nil
 	}
 	// Right is a function reference or other expression.
 	fn, err := Eval(right, input, env)
@@ -87,10 +74,19 @@ func evalChain(right *parser.Node, piped, input any, env *Environment) (any, err
 			if err != nil {
 				return nil, err
 			}
-			return callFunction(fn, []any{intermediate}, focus, env)
+			intermediate = CollapseAndKeep(intermediate, false)
+			res, err := callFunction(fn, []any{intermediate}, focus, env)
+			if err != nil {
+				return nil, err
+			}
+			return CollapseAndKeep(res, false), nil
 		}), nil
 	}
-	return callFunction(fn, []any{piped}, input, env)
+	result, err := callFunction(fn, []any{piped}, input, env)
+	if err != nil {
+		return nil, err
+	}
+	return CollapseAndKeep(result, false), nil
 }
 
 func evalBlock(node *parser.Node, input any, env *Environment) (any, error) {

--- a/internal/evaluator/eval_function.go
+++ b/internal/evaluator/eval_function.go
@@ -76,23 +76,7 @@ func evalFunction(node *parser.Node, input any, env *Environment) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	// Normalize Sequence results: jsonata-js collapses Sequence values
-	// after every function call. Single-element → scalar, multi → []any.
-	// Functions returning *Sequence ($keys, $distinct) rely on this.
-	if seq, ok := result.(*Sequence); ok {
-		result = CollapseSequence(seq)
-	}
-	if node.KeepArray {
-		switch result.(type) {
-		case []any:
-			return result, nil
-		case nil:
-			return nil, nil
-		default:
-			return []any{result}, nil
-		}
-	}
-	return result, nil
+	return CollapseAndKeep(result, node.KeepArray), nil
 }
 
 func evalLambda(node *parser.Node, input any, env *Environment) (any, error) {

--- a/internal/evaluator/value.go
+++ b/internal/evaluator/value.go
@@ -65,6 +65,32 @@ func CollapseSequence(s *Sequence) any {
 	}
 }
 
+// CollapseAndKeep normalizes a function call result for callers that need
+// KeepArray (the [] suffix) support. Builtins returning *Sequence rely on
+// CollapseSequence; when keepArray is true, singletons are preserved as
+// one-element arrays instead of being unwrapped.
+func CollapseAndKeep(result any, keepArray bool) any {
+	if seq, ok := result.(*Sequence); ok {
+		if keepArray {
+			s := *seq
+			s.KeepSingleton = true
+			seq = &s
+		}
+		result = CollapseSequence(seq)
+	}
+	if keepArray {
+		switch result.(type) {
+		case []any:
+			return result
+		case nil:
+			return nil
+		default:
+			return []any{result}
+		}
+	}
+	return result
+}
+
 // IsArray returns true for []any values (not *Sequence).
 func IsArray(v any) bool {
 	_, ok := v.([]any)

--- a/testdata/groups/function-each/case003.json
+++ b/testdata/groups/function-each/case003.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$each({'a': 1}, function($v, $k) { $k })",
+    "data": {},
+    "bindings": {},
+    "result": "a"
+}

--- a/testdata/groups/function-each/case004.json
+++ b/testdata/groups/function-each/case004.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$each({'a': 1}, function($v, $k) { [1, 2, 3] })",
+    "data": {},
+    "bindings": {},
+    "result": [1, 2, 3]
+}

--- a/testdata/groups/function-each/case005.json
+++ b/testdata/groups/function-each/case005.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$each({'a': 1}, function($v, $k) { $k })[]",
+    "data": {},
+    "bindings": {},
+    "result": ["a"]
+}

--- a/testdata/groups/function-each/case006.json
+++ b/testdata/groups/function-each/case006.json
@@ -1,0 +1,7 @@
+{
+    "expr": "$each({'x': {'p': 1, 'q': 2}}, function($v, $k) { $each($v, function($val, $key) { $k & '.' & $key }) })",
+    "data": {},
+    "bindings": {},
+    "result": ["x.p", "x.q"],
+    "unordered": true
+}

--- a/testdata/groups/function-each/case007.json
+++ b/testdata/groups/function-each/case007.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$each({'a': 1}, function($v, $k) { [1, 2, 3] })[]",
+    "data": {},
+    "bindings": {},
+    "result": [[1, 2, 3]]
+}

--- a/testdata/groups/function-match/case000.json
+++ b/testdata/groups/function-match/case000.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$match('hello', /^h/)",
+    "data": {},
+    "bindings": {},
+    "result": {"match": "h", "start": 0, "end": 1, "groups": []}
+}

--- a/testdata/groups/function-match/case001.json
+++ b/testdata/groups/function-match/case001.json
@@ -1,0 +1,9 @@
+{
+    "expr": "$match('hello', /l/)",
+    "data": {},
+    "bindings": {},
+    "result": [
+        {"match": "l", "start": 2, "end": 3, "groups": []},
+        {"match": "l", "start": 3, "end": 4, "groups": []}
+    ]
+}

--- a/testdata/groups/function-match/case002.json
+++ b/testdata/groups/function-match/case002.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$match('hello', /^h/)[]",
+    "data": {},
+    "bindings": {},
+    "result": [{"match": "h", "start": 0, "end": 1, "groups": []}]
+}

--- a/testdata/groups/function-spread/case004.json
+++ b/testdata/groups/function-spread/case004.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$spread({'a': 1})",
+    "data": {},
+    "bindings": {},
+    "result": {"a": 1}
+}

--- a/testdata/groups/function-spread/case005.json
+++ b/testdata/groups/function-spread/case005.json
@@ -1,0 +1,6 @@
+{
+    "expr": "$spread({'a': 1})[]",
+    "data": {},
+    "bindings": {},
+    "result": [{"a": 1}]
+}


### PR DESCRIPTION
## Summary

- **$each**, **$spread**, and **$match** returned `[]any` instead of `*Sequence`, which prevented `CollapseSequence` from performing singleton unwrapping. Per the JSONata spec, when a function returns a single-element sequence the result must be unwrapped to its scalar value.
- The `KeepArray` operator (`[]` suffix) now correctly sets `KeepSingleton` on the `Sequence` before `CollapseSequence` runs, ensuring single-element arrays are preserved when the operator is applied.

## What changed

| File | Change |
|------|--------|
| `functions/object_funcs.go` | `$each` and `$spread` return `*Sequence` instead of `[]any` |
| `functions/string_match_replace.go` | `$match` returns `*Sequence` instead of `[]any` |
| `internal/evaluator/eval_function.go` | Set `KeepSingleton` when `KeepArray` is true, before calling `CollapseSequence` |
| `evaluator_test.go` | New `TestEachSingletonUnwrap` covering scalar, array, nested, and error cases |
| `testdata/groups/function-each/` | 5 new JSON suite tests (case003-case007) |
| `testdata/groups/function-spread/` | 2 new JSON suite tests (case004-case005) |
| `testdata/groups/function-match/` | 3 new JSON suite tests (case000-case002) |

## Examples

```jsonata
/* Before fix: returned ["a=1"], now correctly returns "a=1" */
$each({"a": 1}, function($v, $k) { $k & "=" & $string($v) })

/* Before fix: returned [{"a": 1}], now correctly returns {"a": 1} */
$spread({"a": 1})

/* Before fix: returned [{"match": "h", ...}], now correctly returns {"match": "h", ...} */
$match("hello", /^h/)
```

## Test plan

- [x] All existing JSON suite tests pass
- [x] All existing Go unit tests pass
- [x] New tests verify singleton unwrapping for $each, $spread, $match
- [x] New tests verify KeepArray operator preserves arrays correctly
- [x] Verified parity with jsonata-js reference implementation