### PR TITLE
Release v0.2.2

### DIFF
--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "gnata",
-  "version": "0.2.0",
+  "name": "gnata-js",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "gnata",
-      "version": "0.2.0",
+      "name": "gnata-js",
+      "version": "0.2.2",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.8.0"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnata-js",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Browser JSONata via gnata WASM for backend parity, not a performance optimization",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Bump `gnata-js` from `0.2.1` to `0.2.2` to release the conformance fixes and performance optimizations merged in #13.

## Changes

- `npm/package.json`: `0.2.1` → `0.2.2`
- `npm/package-lock.json`: regenerated (also fixes prior drift — the lockfile still had `name: "gnata"` and `version: "0.2.0"` from before the package was renamed).

## Release flow

`publish-npm.yml` is triggered by tag pushes matching `v*`. After this PR is merged, tag `v0.2.2` on the merge commit and push the tag — npm publish runs via OIDC trusted publishing.

## What's in this release

From #13:

- Signature validation for variadic, optional-skip, context (`-`), and union (`u`) parameter modifiers
- `$split` returns `T0410` on non-string input (JSONata spec alignment)
- Deterministic key iteration for raw `map[string]any` inputs
- Pre-parsed function signatures at registration (no per-call re-parse)
- Eval hot-path optimizations: `float64` arithmetic fast path, primitive `DeepEqual` fast path, reusable HOF argument buffers
- New `Expression.EvalMap` and `Expression.EvalBytesWithVars` APIs
- WASM exports `gnataEvalMap` and `gnataEvalWithVars` for the browser playground
