### PR TITLE
ci: fix npm publish workflow

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,11 +20,8 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install latest npm (required for trusted publishing)
-        run: npm install -g npm@latest
 
       - name: Build WASM and TypeScript
         run: bash scripts/build-npm.sh


### PR DESCRIPTION
## Summary

The `Publish NPM` workflow has been failing at the `npm install -g npm@latest` step on `ubuntu-latest` with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

This is a deterministic self-corruption bug in the bundled-npm → npm@latest in-place upgrade path on Node 22 — it left `@npmcli/arborist` unable to resolve `promise-retry` and blocked the v0.2.2 release (see [run 24951082111](https://github.com/RecoLabs/gnata/actions/runs/24951082111)).

The original step exists only to obtain an npm version new enough for trusted publishing. Node 24 already ships with such an npm, so this PR:

- Bumps `actions/setup-node` to `node-version: '24'`
- Drops the brittle `npm install -g npm@latest` step entirely

Once merged, the publish workflow can be re-run against tag `v0.2.2` to ship the release.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, re-run the `Publish NPM` workflow on tag `v0.2.2` and confirm the package is published to npm
