### PR TITLE
Add jsonata-js 2.2 test parity and guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,122 +238,24 @@ For point-in-time cache stats without a hook, use `se.Stats()` which returns hit
 
 ## Performance
 
-All benchmarks on Apple M4 Pro. gnata is compared against the reference [jsonata-js](https://github.com/jsonata-js/jsonata) implementation running in Node.js. The **JSONata (eval)** column estimates pure evaluation time by subtracting RPC overhead from the total; entries showing `< 1 us` mean the expression evaluated faster than the measurement floor.
+All benchmarks on Apple M4 Pro. gnata is compared against the reference [jsonata-js](https://github.com/jsonata-js/jsonata) implementation running in Node.js, evaluation time only (no RPC/transport overhead). Simple field lookups and comparisons hit a zero-copy GJSON fast path — the JSON document is never fully parsed — and functions on a pure path (e.g. `$exists(a.b)`, `$lowercase(name)`) get a similar fast path via a single `gjson.GetBytes` call.
 
-### Fast Path (GJSON zero-copy)
+| Category | gnata latency | Speedup vs JSONata |
+|---|---|---|
+| Fast Path (GJSON zero-copy) | 41 ns – 142 ns | 570x – 1,500x* |
+| Boolean Logic | 127 ns – 573 ns | 43x – 270x |
+| Numeric & Arithmetic | 177 ns – 530 ns | 32x – 200x* |
+| String Functions | 73 ns – 580 ns | 7x – 360x* |
+| Array & Filtering | 195 ns – 573 ns | 24x – 140x |
+| Higher-Order Functions & Lambdas | 425 ns – 1.5 µs | 8x – 88x* |
+| Joins (`@` operator) | 545 ns – 1.6 µs | up to 19x* |
+| Conditionals & Blocks | 170 ns – 7.1 µs | 3x – 68x* |
+| Regex | 497 ns – 947 ns | up to 6x* |
+| Complex Boolean Expressions | 202 ns – 928 ns | up to 31x* |
 
-Simple field lookups and comparisons are evaluated directly against raw `json.RawMessage` via GJSON — the JSON document is never fully parsed.
+\* Some expressions in this category evaluate faster than JSONata's measurement floor (< 1 µs) — actual speedup is understated.
 
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `field.lookup` | **55 ns** | 83 us | 232 us | 1,500x |
-| `nested.3.deep` | **95 ns** | 56 us | 205 us | 590x |
-| `field = "string"` | **42 ns** | 49 us | 197 us | 1,170x |
-| `field = 2` (numeric) | **142 ns** | 163 us | 311 us | 1,150x |
-| `field = true` (bool) | **111 ns** | 64 us | 212 us | 570x |
-| `field != null` | **41 ns** | 23 us | 172 us | 570x |
-| `field != "value"` | **41 ns** | < 1 us | 147 us | — |
-
-Fast-path expressions typically achieve **0-2 allocations** and **0-40 bytes** per evaluation.
-
-### Function fast path
-
-Expressions calling a supported built-in function on a pure path (e.g. `$exists(a.b)`, `$lowercase(name)`, `$contains(path, "literal")`) are classified at compile time. At runtime, the field is extracted with a single `gjson.GetBytes` call and the function is applied directly — no `json.Unmarshal`, no AST walk.
-
-Supported functions (21): `$exists`, `$contains`, `$string`, `$boolean`, `$number`, `$keys`, `$distinct`, `$not`, `$lowercase`, `$uppercase`, `$trim`, `$length`, `$type`, `$abs`, `$floor`, `$ceil`, `$sqrt`, `$count`, `$reverse`, `$sum`, `$max`, `$min`, `$average`.
-
-### Boolean Logic
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `a = "x" and b = "y"` | **573 ns** | 24 us | 173 us | 43x |
-| `a = "x" or a = "y"` | **144 ns** | 38 us | 187 us | 270x |
-| `$not(field)` | **127 ns** | 7 us | 156 us | 58x |
-| `(a or b) and c` | **194 ns** | 17 us | 166 us | 88x |
-| `a and b and c` (3-way) | **180 ns** | 11 us | 159 us | 59x |
-
-### Numeric & Arithmetic
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `field > 1` | **191 ns** | < 1 us | 148 us | — |
-| `(field + 1) * 10` | **200 ns** | 12 us | 160 us | 58x |
-| `field in [1, 2, 3]` | **530 ns** | 17 us | 165 us | 32x |
-| `$sum(array)` | **177 ns** | < 1 us | 144 us | — |
-| `$average(array)` | **190 ns** | < 1 us | 143 us | — |
-| `$max(a) - $min(a)` | **264 ns** | 52 us | 201 us | 200x |
-
-### String Functions
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `$uppercase(field)` | **117 ns** | < 1 us | 139 us | — |
-| `$contains(field, "sub")` | **73 ns** | < 1 us | 111 us | — |
-| `$split(email, "@")` | **247 ns** | 90 us | 238 us | 360x |
-| `$join(array, ", ")` | **233 ns** | < 1 us | 140 us | — |
-| `a & "-" & b` (concat) | **580 ns** | 4 us | 153 us | 7x |
-| `$replace(field, "x", "y")` | **234 ns** | < 1 us | 142 us | — |
-| `$uppercase($substringBefore(...))` | **314 ns** | < 1 us | 140 us | — |
-
-### Array & Filtering
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `$count(array)` | **406 ns** | 13 us | 162 us | 33x |
-| `items[active = true].name` | **551 ns** | 13 us | 162 us | 24x |
-| `items[value > 20].name` | **573 ns** | 39 us | 188 us | 68x |
-| `$count(items[active])` | **378 ns** | 42 us | 190 us | 110x |
-| `items.name` (auto-map) | **247 ns** | 34 us | 183 us | 140x |
-| `items^(value).name` (sort) | **524 ns** | 68 us | 216 us | 130x |
-| `items^(>value).name` (desc) | **509 ns** | 41 us | 189 us | 80x |
-| `$reverse(array)` | **195 ns** | 20 us | 168 us | 100x |
-
-### Higher-Order Functions & Lambdas
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `$map(items, function($v) { ... })` | **1.2 us** | 108 us | 256 us | 88x |
-| `$filter(items, function($v) { ... })` | **1.1 us** | 41 us | 190 us | 38x |
-| `$reduce(array, function($p,$c) { ... })` | **1.0 us** | 8 us | 156 us | 8x |
-| `$sort(items, function($a,$b) { ... })` | **1.5 us** | 79 us | 228 us | 53x |
-| `$map(tags, $uppercase)` | **425 ns** | < 1 us | 143 us | — |
-| `$single(users, function($v) { ... })` | **806 ns** | 7 us | 155 us | 8x |
-
-### Joins (`@` operator)
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| 2-way join (`loans@$l.books@$b[...]`) | **545 ns** | < 1 us | 144 us | — |
-| Join with index (`#$i`) | **1.6 us** | 31 us | 180 us | 19x |
-
-### Conditionals & Blocks
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `a = 2 ? "yes" : "no"` | **170 ns** | < 1 us | 146 us | — |
-| Nested ternary | **188 ns** | < 1 us | 144 us | — |
-| `( $x := field; $x * $x )` | **268 ns** | < 1 us | 146 us | — |
-| Multi-variable block | **257 ns** | 18 us | 166 us | 68x |
-| `**.field` (recursive descent) | **7.1 us** | 20 us | 168 us | 3x |
-
-### Regex
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| `$contains(field, /pattern/)` | **497 ns** | 3 us | 151 us | 6x |
-| `$match(field, /groups/)` | **947 ns** | < 1 us | 144 us | — |
-| `$replace(field, /capture/, "$1")` | **835 ns** | < 1 us | 141 us | — |
-
-### Complex Boolean Expressions
-
-| Expression | gnata | JSONata (eval) | JSONata (RPC) | Speedup |
-|---|---|---|---|---|
-| 3-way AND compound | **202 ns** | < 1 us | 141 us | — |
-| Membership + numeric guard | **215 ns** | < 1 us | 147 us | — |
-| `$exists` + field checks | **219 ns** | < 1 us | 148 us | — |
-| String pattern matching | **221 ns** | 7 us | 155 us | 31x |
-| Filter + count threshold | **487 ns** | < 1 us | 143 us | — |
-| Filter + map + join pipeline | **928 ns** | < 1 us | 146 us | — |
+Fast-path expressions typically achieve **0-2 allocations** and **0-40 bytes** per evaluation. Supported fast-path functions (21): `$exists`, `$contains`, `$string`, `$boolean`, `$number`, `$keys`, `$distinct`, `$not`, `$lowercase`, `$uppercase`, `$trim`, `$length`, `$type`, `$abs`, `$floor`, `$ceil`, `$sqrt`, `$count`, `$reverse`, `$sum`, `$max`, `$min`, `$average`.
 
 ### StreamEvaluator (batch of 4 expressions)
 
@@ -366,7 +268,7 @@ Supported functions (21): `$exists`, `$contains`, `$string`, `$boolean`, `$numbe
 
 ## JSONata Compatibility
 
-gnata targets full compatibility with [JSONata 2.x](https://docs.jsonata.org), validated against **1,778 test cases** from the official [jsonata-js test suite](https://github.com/jsonata-js/jsonata/tree/master/test/test-suite) — **0 failures, 0 skips**.
+gnata targets full compatibility with [JSONata 2.x](https://docs.jsonata.org), validated against **1,704 test cases** from the official [jsonata-js test suite](https://github.com/jsonata-js/jsonata/tree/master/test/test-suite) at **v2.2.2** — **0 failures, 0 skips**.
 
 ### Supported Features
 
@@ -391,6 +293,20 @@ gnata targets full compatibility with [JSONata 2.x](https://docs.jsonata.org), v
 | **Boolean** | `$boolean` `$not` `$exists` |
 | **Higher-Order** | `$map` `$filter` `$reduce` `$single` |
 | **Date/Time** | `$now` `$millis` `$fromMillis` `$toMillis` |
+
+### Guardrails
+
+`Compile` accepts optional resource guardrails, matching jsonata-js 2.2's `stack` / `timeout` / `sequence` options:
+
+```go
+expr, err := gnata.Compile(userExpr,
+    gnata.WithStack(100),                // error D1011 beyond this recursion depth
+    gnata.WithTimeout(500*time.Millisecond), // error D1012 if evaluation runs longer
+    gnata.WithSequence(1_000_000),       // error D2015 if a built sequence grows past this
+)
+```
+
+All three are opt-in; without them gnata keeps its existing defaults (100-deep call stack → `U1001`, no timeout beyond the caller's `context.Context`, and the built-in 10,000,000-element hard caps on the range operator and `$append`). `WithSequence` bounds every major sequence-growth path: the range operator, `$append`, `$map`, `$filter`, `$each`, wildcard (`*`), and descendant (`**`). Use guardrails when evaluating expressions from an untrusted source.
 
 ## Known Behavioral Differences from jsonata-js
 

--- a/functions/array_funcs.go
+++ b/functions/array_funcs.go
@@ -28,7 +28,7 @@ func fnCount(args []any, _ any) (any, error) {
 
 // ── $append ───────────────────────────────────────────────────────────────────
 
-func fnAppend(args []any, _ any) (any, error) {
+func fnAppend(args []any, _ any, env *evaluator.Environment) (any, error) {
 	if len(args) < 2 {
 		return nil, &evaluator.JSONataError{Code: "D3006", Message: "$append: requires 2 arguments"}
 	}
@@ -41,6 +41,9 @@ func fnAppend(args []any, _ any) (any, error) {
 	}
 	a := wrapArray(args[0])
 	b := wrapArray(args[1])
+	if err := env.CheckSequence(len(a) + len(b)); err != nil {
+		return nil, err
+	}
 	const maxAppendSize = 10_000_000
 	if len(a)+len(b) > maxAppendSize {
 		return nil, &evaluator.JSONataError{

--- a/functions/hof_funcs.go
+++ b/functions/hof_funcs.go
@@ -82,6 +82,9 @@ func makeFnMap(evalFn EvalFn) evaluator.EnvAwareBuiltin {
 			}
 			if val != nil {
 				seq.Values = append(seq.Values, val)
+				if err := env.CheckSequence(len(seq.Values)); err != nil {
+					return nil, err
+				}
 			}
 		}
 		return evaluator.CollapseSequence(seq), nil
@@ -121,6 +124,9 @@ func makeFnFilter(evalFn EvalFn) evaluator.EnvAwareBuiltin {
 			}
 			if evaluator.ToBoolean(val) {
 				seq.Values = append(seq.Values, item)
+				if err := env.CheckSequence(len(seq.Values)); err != nil {
+					return nil, err
+				}
 			}
 		}
 		if inputWasArray {

--- a/functions/object_funcs.go
+++ b/functions/object_funcs.go
@@ -252,6 +252,9 @@ func makeFnEach(evalFn EvalFn) evaluator.EnvAwareBuiltin {
 			}
 			if res != nil {
 				seq.Values = append(seq.Values, res)
+				if err := env.CheckSequence(len(seq.Values)); err != nil {
+					return nil, err
+				}
 			}
 		}
 		return seq, nil

--- a/functions/register.go
+++ b/functions/register.go
@@ -53,7 +53,6 @@ var builtinFuncs = []struct {
 	{"average", fnAverage},
 	// ── Array ─────────────────────────────────────────────────────────────────
 	{"count", fnCount},
-	{"append", fnAppend},
 	{"reverse", fnReverse},
 	{"shuffle", fnShuffle},
 	{"distinct", fnDistinct},
@@ -91,6 +90,7 @@ func RegisterAll(env *evaluator.Environment, evalFn EvalFn) {
 	for _, b := range builtinFuncs {
 		env.Bind(b.name, evaluator.BuiltinFunction(b.fn))
 	}
+	env.Bind("append", evaluator.EnvAwareBuiltin(fnAppend))
 	env.Bind("uppercase", newSignedBuiltin(fnUppercase, "s-:s"))
 	env.Bind("lowercase", newSignedBuiltin(fnLowercase, "s-:s"))
 	env.Bind("match", makeFnMatch(evalFn))

--- a/functions/string_funcs.go
+++ b/functions/string_funcs.go
@@ -395,6 +395,10 @@ func fnContains(args []any, focus any) (any, error) {
 		return nil, &evaluator.JSONataError{Code: "T0410", Message: "$contains: argument 1 must be a string"}
 	}
 
+	if args[1] == nil {
+		return nil, nil
+	}
+
 	switch p := args[1].(type) {
 	case string:
 		return strings.Contains(s, p), nil

--- a/gnata.go
+++ b/gnata.go
@@ -12,9 +12,11 @@ package gnata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/recolabs/gnata/functions"
 	"github.com/recolabs/gnata/internal/evaluator"
@@ -35,11 +37,55 @@ type Expression struct {
 	// funcFast covers built-in function calls on a pure path (e.g. `$exists(a.b)`).
 	// Non-nil when the expression qualifies; nil otherwise.
 	funcFast *parser.FuncFastPath
+	// guardrails holds optional resource limits set via Compile options.
+	// nil when Compile was called without options (default, unlimited behavior).
+	guardrails *guardrails
+}
+
+// guardrails holds the resource limits configured via Option, matching the
+// jsonata-js 2.2 guardrails API (stack / timeout / sequence).
+type guardrails struct {
+	stack    int
+	timeout  time.Duration
+	sequence int
+}
+
+// errGuardrailTimeout tags the context cause set by WithTimeout, so evalCore
+// can distinguish a guardrail timeout (error D1012) from the caller's own
+// context cancellation (propagated as-is).
+var errGuardrailTimeout = errors.New("gnata: guardrail timeout exceeded")
+
+// Option configures an optional resource guardrail on a compiled Expression.
+// See WithStack, WithTimeout, and WithSequence.
+type Option func(*guardrails)
+
+// WithStack limits the maximum lambda recursion depth. Exceeding it returns
+// error D1011. Without this option, gnata still enforces its built-in limit
+// of 100 (error U1001) — WithStack only changes the limit and the resulting
+// error code, matching jsonata-js's `stack` guardrail.
+func WithStack(n int) Option {
+	return func(g *guardrails) { g.stack = n }
+}
+
+// WithTimeout limits total evaluation time. Exceeding it returns error
+// D1012. Without this option, evaluation is bounded only by the ctx passed
+// to Eval, matching jsonata-js's `timeout` guardrail.
+func WithTimeout(d time.Duration) Option {
+	return func(g *guardrails) { g.timeout = d }
+}
+
+// WithSequence limits the length of sequences built during evaluation: the
+// range operator (..), $append, $map, $filter, $each, wildcard (*), and
+// descendant (**). Exceeding it returns error D2015, matching jsonata-js's
+// `sequence` guardrail. Without this option, only the built-in 10,000,000
+// element hard caps (D2014 / D3010) apply.
+func WithSequence(n int) Option {
+	return func(g *guardrails) { g.sequence = n }
 }
 
 // Compile parses a JSONata expression string and returns an Expression.
 // The returned Expression is goroutine-safe and should be reused across calls.
-func Compile(expr string) (*Expression, error) {
+func Compile(expr string, opts ...Option) (*Expression, error) {
 	p := parser.NewParser(expr)
 	ast, err := p.Parse()
 	if err != nil {
@@ -50,13 +96,21 @@ func Compile(expr string) (*Expression, error) {
 		return nil, err
 	}
 	fp := parser.AnalyzeFastPath(ast)
+	var g *guardrails
+	if len(opts) > 0 {
+		g = &guardrails{}
+		for _, opt := range opts {
+			opt(g)
+		}
+	}
 	return &Expression{
-		src:      expr,
-		ast:      ast,
-		fastPath: fp.IsFastPath,
-		paths:    fp.GJSONPaths,
-		cmpFast:  fp.CmpFast,
-		funcFast: fp.FuncFast,
+		src:        expr,
+		ast:        ast,
+		fastPath:   fp.IsFastPath,
+		paths:      fp.GJSONPaths,
+		cmpFast:    fp.CmpFast,
+		funcFast:   fp.FuncFast,
+		guardrails: g,
 	}, nil
 }
 
@@ -181,15 +235,31 @@ func recoverEvalPanic(errp *error) { //nolint:gocritic // ptrToRefParam: must mu
 // evalCore is the shared evaluation logic for all Eval variants.
 func (e *Expression) evalCore(ctx context.Context, data any, parent *evaluator.Environment, vars map[string]any) (result any, err error) {
 	defer recoverEvalPanic(&err)
+	if e.guardrails != nil && e.guardrails.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeoutCause(ctx, e.guardrails.timeout, errGuardrailTimeout)
+		defer cancel()
+	}
 	env := evaluator.NewChildEnvironment(parent)
 	env.ResetCallCounter()
 	env.SetContext(ctx)
+	if e.guardrails != nil {
+		if e.guardrails.stack > 0 {
+			env.SetMaxStackDepth(e.guardrails.stack)
+		}
+		if e.guardrails.sequence > 0 {
+			env.SetMaxSequence(e.guardrails.sequence)
+		}
+	}
 	env.Bind("$", data)
 	for k, v := range vars {
 		env.Bind(k, v)
 	}
 	result, err = evaluator.Eval(e.ast, data, env)
 	if err != nil {
+		if e.guardrails != nil && e.guardrails.timeout > 0 && errors.Is(context.Cause(ctx), errGuardrailTimeout) {
+			return nil, &evaluator.JSONataError{Code: "D1012", Message: fmt.Sprintf("Evaluation timeout after %s", e.guardrails.timeout)}
+		}
 		return nil, err
 	}
 	if seq, ok := result.(*evaluator.Sequence); ok {

--- a/guardrails_test.go
+++ b/guardrails_test.go
@@ -1,0 +1,134 @@
+package gnata_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/recolabs/gnata"
+)
+
+func TestGuardrailsDefaultUnaffected(t *testing.T) {
+	const factorial = "$factorial := function($n){$n = 0 ? 1 : $n * $factorial($n - 1)}"
+	testCases := []struct {
+		desc string
+		expr string
+		want any
+		code string
+	}{
+		{desc: "factorial 99 within default stack", expr: "(" + factorial + "; $factorial(99))", want: 9.33262154439441e+155},
+		{desc: "factorial 100 exceeds default stack", expr: "(" + factorial + "; $factorial(100))", code: "U1001"},
+		{desc: "range at hard cap", expr: "1..10000001", code: "D2014"},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			e, err := gnata.Compile(tC.expr)
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			got, err := e.Eval(context.Background(), nil)
+			if tC.code != "" {
+				if err == nil || !strings.Contains(err.Error(), tC.code) {
+					t.Fatalf("expected error code %s, got result=%v err=%v", tC.code, got, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+			if !gnata.DeepEqual(got, tC.want) {
+				t.Fatalf("want %v, got %v", tC.want, got)
+			}
+		})
+	}
+}
+
+func TestWithStack(t *testing.T) {
+	e, err := gnata.Compile(
+		"($factorial := function($n){$n = 0 ? 1 : $n * $factorial($n - 1)}; $factorial(20))",
+		gnata.WithStack(5),
+	)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	_, err = e.Eval(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "D1011") {
+		t.Fatalf("expected D1011, got %v", err)
+	}
+}
+
+func TestWithTimeout(t *testing.T) {
+	e, err := gnata.Compile("1..10000000#$i[$i % 2 = 0]", gnata.WithTimeout(1*time.Nanosecond))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	_, err = e.Eval(context.Background(), nil)
+	if err == nil || !strings.Contains(err.Error(), "D1012") {
+		t.Fatalf("expected D1012, got %v", err)
+	}
+}
+
+func TestWithTimeout_ParentCancellationPreserved(t *testing.T) {
+	e, err := gnata.Compile("1+1", gnata.WithTimeout(time.Minute))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = e.Eval(ctx, nil)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestWithSequence(t *testing.T) {
+	wideObject := map[string]any{}
+	for i := range 20 {
+		wideObject[fmt.Sprintf("k%d", i)] = i
+	}
+	testCases := []struct {
+		desc string
+		expr string
+		data any
+	}{
+		{desc: "range exceeds sequence guardrail", expr: "1..100"},
+		{desc: "append exceeds sequence guardrail", expr: "$append([1,2,3,4,5,6], [7,8,9,10,11,12])"},
+		{desc: "map exceeds sequence guardrail", expr: "$map([1,2,3,4,5,6,7,8,9,10,11,12], function($x){$x})"},
+		{desc: "filter exceeds sequence guardrail", expr: "$filter([1,2,3,4,5,6,7,8,9,10,11,12], function($x){true})"},
+		{
+			desc: "each exceeds sequence guardrail",
+			expr: "$each({'a':1,'b':2,'c':3,'d':4,'e':5,'f':6,'g':7,'h':8,'i':9,'j':10,'k':11}, function($v,$k){$v})",
+		},
+		{desc: "wildcard exceeds sequence guardrail", expr: "*", data: wideObject},
+		{desc: "descendant exceeds sequence guardrail", expr: "**", data: wideObject},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			e, err := gnata.Compile(tC.expr, gnata.WithSequence(10))
+			if err != nil {
+				t.Fatalf("compile: %v", err)
+			}
+			_, err = e.Eval(context.Background(), tC.data)
+			if err == nil || !strings.Contains(err.Error(), "D2015") {
+				t.Fatalf("expected D2015, got %v", err)
+			}
+		})
+	}
+}
+
+func TestWithSequence_UnderLimitUnaffected(t *testing.T) {
+	e, err := gnata.Compile("1..5", gnata.WithSequence(10))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	got, err := e.Eval(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !gnata.DeepEqual(got, []any{1.0, 2.0, 3.0, 4.0, 5.0}) {
+		t.Fatalf("got %v", got)
+	}
+}

--- a/internal/evaluator/env.go
+++ b/internal/evaluator/env.go
@@ -2,6 +2,7 @@ package evaluator
 
 import (
 	"context"
+	"fmt"
 	"maps"
 
 	"github.com/recolabs/gnata/internal/parser"
@@ -14,9 +15,11 @@ const defaultMaxCallDepth = 100
 // callCounter tracks the current recursive call depth across all child environments.
 // A pointer is shared so all nested envs increment/decrement the same counter.
 type callCounter struct {
-	depth     int
-	evalDepth int
-	max       int
+	depth        int
+	evalDepth    int
+	max          int
+	stackIsLimit bool // true when max was set via the WithStack guardrail (error D1011 instead of U1001)
+	maxSequence  int  // 0 = unlimited; guardrail set via WithSequence (error D2015)
 }
 
 // Environment holds variable bindings for an evaluation context.
@@ -116,6 +119,30 @@ func (e *Environment) IncrEvalDepth(maxDepth int) error {
 func (e *Environment) DecrEvalDepth() {
 	c := e.callCounter()
 	c.evalDepth--
+}
+
+// SetMaxStackDepth overrides the recursion depth limit as a guardrail: once set,
+// exceeding it returns error D1011 instead of the default U1001.
+func (e *Environment) SetMaxStackDepth(n int) {
+	c := e.callCounter()
+	c.max = n
+	c.stackIsLimit = true
+}
+
+// SetMaxSequence sets the guardrail sequence-length limit (0 = unlimited).
+// Exceeding it at a checked growth site returns error D2015.
+func (e *Environment) SetMaxSequence(n int) {
+	e.callCounter().maxSequence = n
+}
+
+// CheckSequence returns a D2015 error if n exceeds the configured sequence
+// guardrail. No-op when no guardrail is set.
+func (e *Environment) CheckSequence(n int) error {
+	c := e.callCounter()
+	if c.maxSequence > 0 && n > c.maxSequence {
+		return &JSONataError{Code: "D2015", Message: fmt.Sprintf("The maximum sequence length of %d was exceeded", c.maxSequence)}
+	}
+	return nil
 }
 
 // Clone creates a shallow copy of the environment, duplicating the bindings map

--- a/internal/evaluator/eval_binary.go
+++ b/internal/evaluator/eval_binary.go
@@ -295,6 +295,9 @@ func evalSubscriptLeft(node *parser.Node, input any, env *Environment) (left any
 		descSeq := CreateSequence()
 		appendToSequence(descSeq, input)
 		appendToSequence(descSeq, descendantLookup(input))
+		if err := env.CheckSequence(len(descSeq.Values)); err != nil {
+			return nil, nil, err
+		}
 		left = CollapseSequence(descSeq)
 	} else {
 		var err error

--- a/internal/evaluator/eval_function.go
+++ b/internal/evaluator/eval_function.go
@@ -152,6 +152,19 @@ func evalPartial(node *parser.Node, input any, env *Environment) (any, error) {
 	return partial, nil
 }
 
+// stackOverflowError reports the recursion-depth error for the given counter,
+// using D1011 when the limit came from the WithStack guardrail and the
+// built-in U1001 otherwise.
+func stackOverflowError(counter *callCounter) error {
+	if counter.stackIsLimit {
+		return &JSONataError{
+			Code:    "D1011",
+			Message: fmt.Sprintf("Stack overflow error: stack depth exceeded %d. Check for non-terminating recursive function", counter.max),
+		}
+	}
+	return &JSONataError{Code: "U1001", Message: fmt.Sprintf("stack overflow error: evaluation exceeded stack depth %d", counter.max)}
+}
+
 func callFunction(fn any, args []any, focus any, env *Environment) (any, error) {
 	if fn == nil {
 		return nil, &JSONataError{Code: "T1006", Message: "attempted to invoke undefined function"}
@@ -189,7 +202,7 @@ func callFunction(fn any, args []any, focus any, env *Environment) (any, error) 
 			counter.depth++
 			if counter.depth > counter.max {
 				counter.depth--
-				return nil, &JSONataError{Code: "U1001", Message: fmt.Sprintf("stack overflow error: evaluation exceeded stack depth %d", counter.max)}
+				return nil, stackOverflowError(counter)
 			}
 			childEnv := NewChildEnvironment(f.Closure)
 			childEnv.calls = counter

--- a/internal/evaluator/eval_helpers.go
+++ b/internal/evaluator/eval_helpers.go
@@ -307,7 +307,7 @@ func evalName(node *parser.Node, input any, _ *Environment) (any, error) {
 	}
 }
 
-func evalWildcard(_ *parser.Node, input any, _ *Environment) (any, error) {
+func evalWildcard(_ *parser.Node, input any, env *Environment) (any, error) {
 	if IsMap(input) {
 		if MapLen(input) == 0 {
 			return nil, nil
@@ -324,6 +324,9 @@ func evalWildcard(_ *parser.Node, input any, _ *Environment) (any, error) {
 		if len(seq.Values) == 0 {
 			return nil, nil
 		}
+		if err := env.CheckSequence(len(seq.Values)); err != nil {
+			return nil, err
+		}
 		if len(seq.Values) == 1 {
 			return seq.Values[0], nil
 		}
@@ -334,7 +337,7 @@ func evalWildcard(_ *parser.Node, input any, _ *Environment) (any, error) {
 		seq := CreateSequence()
 		for _, item := range v {
 			if IsMap(item) {
-				val, err := evalWildcard(nil, item, nil)
+				val, err := evalWildcard(nil, item, env)
 				if err != nil {
 					return nil, err
 				}
@@ -344,6 +347,9 @@ func evalWildcard(_ *parser.Node, input any, _ *Environment) (any, error) {
 			} else if item != nil {
 				seq.Values = append(seq.Values, item)
 			}
+		}
+		if err := env.CheckSequence(len(seq.Values)); err != nil {
+			return nil, err
 		}
 		return CollapseSequence(seq), nil
 	default:

--- a/internal/evaluator/eval_range.go
+++ b/internal/evaluator/eval_range.go
@@ -34,6 +34,10 @@ func evalRange(left, right any, env *Environment) (any, error) {
 	if lo > hi {
 		return nil, nil
 	}
+	size := hi - lo + 1
+	if err := env.CheckSequence(size); err != nil {
+		return nil, err
+	}
 	const maxRange = 10_000_000
 	if hi-lo >= maxRange {
 		return nil, &JSONataError{Code: "D2014", Message: fmt.Sprintf("range operator (..) must not exceed %d items", maxRange)}

--- a/internal/evaluator/evaluator.go
+++ b/internal/evaluator/evaluator.go
@@ -34,7 +34,7 @@ func Eval(node *parser.Node, input any, env *Environment) (any, error) {
 	case parser.NodeWildcard:
 		return evalWildcard(node, input, env)
 	case parser.NodeDescendant:
-		return descendantLookup(input), nil
+		return evalDescendant(input, env)
 	case parser.NodePath:
 		return evalPath(node, input, env)
 	case parser.NodeBinary, parser.NodeApply:
@@ -75,6 +75,16 @@ func Eval(node *parser.Node, input any, env *Environment) (any, error) {
 	default:
 		return nil, fmt.Errorf("unknown node type: %s", node.Type)
 	}
+}
+
+// evalDescendant evaluates the ** operator, enforcing the sequence guardrail
+// (if any) on the collected result.
+func evalDescendant(input any, env *Environment) (any, error) {
+	seq := descendantLookup(input)
+	if err := env.CheckSequence(len(seq.Values)); err != nil {
+		return nil, err
+	}
+	return seq, nil
 }
 
 // ApplyFunction is the public API used by the standard library to call

--- a/internal/evaluator/path.go
+++ b/internal/evaluator/path.go
@@ -269,7 +269,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 			}
 			ctxs = nextCtxs
 			if len(ctxs) == 0 {
-				return nil, nil
+				break
 			}
 			continue
 		}
@@ -300,7 +300,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 			}
 			ctxs = nextCtxs
 			if len(ctxs) == 0 {
-				return nil, nil
+				break
 			}
 			continue
 		}
@@ -355,7 +355,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 			}
 			ctxs = nextCtxs
 			if len(ctxs) == 0 {
-				return nil, nil
+				break
 			}
 			continue
 		}
@@ -373,7 +373,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 			}
 			ctxs = nextCtxs
 			if len(ctxs) == 0 {
-				return nil, nil
+				break
 			}
 			continue
 		}
@@ -400,7 +400,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 			}
 			ctxs = nextCtxs
 			if len(ctxs) == 0 {
-				return nil, nil
+				break
 			}
 			continue
 		}
@@ -445,7 +445,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 
 			ctxs = nextCtxs
 			if len(ctxs) == 0 {
-				return nil, nil
+				break
 			}
 			continue
 		}
@@ -489,7 +489,7 @@ func evalPathTuple(node *parser.Node, input any, env *Environment) (any, error) 
 
 		ctxs = nextCtxs
 		if len(ctxs) == 0 {
-			return nil, nil
+			break
 		}
 	}
 
@@ -943,9 +943,6 @@ func evalTupleGroup(group *parser.GroupExpr, ctxs []pathCtx) (any, error) {
 		}
 	}
 
-	if result.Len() == 0 {
-		return nil, nil
-	}
 	return result, nil
 }
 
@@ -1045,21 +1042,7 @@ func evalPathStep(
 			return Eval(step, input, env)
 		}
 	case parser.NodeDescendant:
-		// The descendant operator in a path (A.**.B) must include A itself in the
-		// search so that B can be found at any depth INCLUDING the current level.
-		// Arrays are transparent containers: their elements are already included
-		// by descendantLookup, so adding the array itself would cause duplicate
-		// results when subsequent field lookups auto-map through both the array
-		// and its individually-included elements.
-		seq := CreateSequence()
-		if _, isArr := input.([]any); !isArr {
-			appendToSequence(seq, input)
-		}
-		appendToSequence(seq, descendantLookup(input))
-		if len(seq.Values) == 0 {
-			return nil, nil
-		}
-		return seq, nil
+		return evalPathStepDescendant(input, env)
 	case parser.NodeBinary:
 		// Subscript steps map per-element when preceded by a mapping step (prevWasMapper=true).
 		// When NOT preceded by a mapper, apply the subscript to the whole collected array.
@@ -1124,6 +1107,27 @@ func evalPathStep(
 		return seq.Values, nil
 	}
 	return CollapseSequence(seq), nil
+}
+
+// evalPathStepDescendant evaluates a ** path step. It must include the input
+// itself in the search so that a later step can match at the current level
+// too, not just at deeper ones. Arrays are transparent containers: their
+// elements are already included by descendantLookup, so adding the array
+// itself would cause duplicate results when subsequent field lookups
+// auto-map through both the array and its individually-included elements.
+func evalPathStepDescendant(input any, env *Environment) (any, error) {
+	seq := CreateSequence()
+	if _, isArr := input.([]any); !isArr {
+		appendToSequence(seq, input)
+	}
+	appendToSequence(seq, descendantLookup(input))
+	if err := env.CheckSequence(len(seq.Values)); err != nil {
+		return nil, err
+	}
+	if len(seq.Values) == 0 {
+		return nil, nil
+	}
+	return seq, nil
 }
 
 // evalPathFunctionStep evaluates a NodeFunction step in path context.

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gnata-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gnata-js",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.8.0"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnata-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Browser JSONata via gnata WASM for backend parity, not a performance optimization",
   "license": "MIT",
   "repository": {

--- a/testdata/groups/coalescing-operator/case013.json
+++ b/testdata/groups/coalescing-operator/case013.json
@@ -1,0 +1,7 @@
+{
+    "description": "array predicate on lhs exists, should return lhs value",
+    "expr": "foo.blah[0] ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {"baz": {"fud": "hello"}}
+}

--- a/testdata/groups/coalescing-operator/case014.json
+++ b/testdata/groups/coalescing-operator/case014.json
@@ -1,0 +1,7 @@
+{
+    "description": "array predicate on lhs does not exist, should return rhs value",
+    "expr": "foo.blah[5] ?? 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}

--- a/testdata/groups/default-operator/case014.json
+++ b/testdata/groups/default-operator/case014.json
@@ -1,0 +1,8 @@
+{
+    "description": "array predicate on lhs exists, should return lhs value",
+    "expr": "foo.blah[0] ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": {"baz": {"fud": "hello"}}
+}
+

--- a/testdata/groups/default-operator/case015.json
+++ b/testdata/groups/default-operator/case015.json
@@ -1,0 +1,8 @@
+{
+    "description": "array predicate on lhs does not exist, should return rhs value",
+    "expr": "foo.blah[5] ?: 42",
+    "dataset": "dataset0",
+    "bindings": {},
+    "result": 42
+}
+

--- a/testdata/groups/default-operator/case016.json
+++ b/testdata/groups/default-operator/case016.json
@@ -1,0 +1,8 @@
+{
+    "description": "negative array index on lhs returns last element",
+    "expr": "[1,2,3][-1] ?: 42",
+    "dataset": null,
+    "bindings": {},
+    "result": 3
+}
+

--- a/testdata/groups/default-operator/case017.json
+++ b/testdata/groups/default-operator/case017.json
@@ -1,0 +1,8 @@
+{
+    "description": "negative array index on single-element array returns the element",
+    "expr": "[true][-1] ?: \"no\"",
+    "dataset": null,
+    "bindings": {},
+    "result": true
+}
+

--- a/testdata/groups/default-operator/case018.json
+++ b/testdata/groups/default-operator/case018.json
@@ -1,0 +1,8 @@
+{
+    "description": "unary minus on number literal LHS is not double-negated",
+    "expr": "-5 ?: 99",
+    "dataset": null,
+    "bindings": {},
+    "result": -5
+}
+

--- a/testdata/groups/function-contains/case007.json
+++ b/testdata/groups/function-contains/case007.json
@@ -1,0 +1,7 @@
+{
+    "expr": "$contains(\"Hello World\", nothing)",
+    "dataset": null,
+    "bindings": {},
+    "undefinedResult": true
+}
+

--- a/testdata/groups/function-each/case008.json
+++ b/testdata/groups/function-each/case008.json
@@ -1,0 +1,5 @@
+{
+    "expr": "$each(input.data, function($v, $k) {$v})",
+    "data": { "input": {}, "output": {} },
+    "undefinedResult": true
+}

--- a/testdata/groups/function-tomillis/parseDateTime.json
+++ b/testdata/groups/function-tomillis/parseDateTime.json
@@ -366,5 +366,13 @@
         "expr": "$toMillis('2020-09-09 12:00:00 +0530', '[Y0001]-[M01]-[D01] [H01]:[m01]:[s01] [Z0001]') ~> $fromMillis() ",
         "data": {},
         "result": "2020-09-09T06:30:00.000Z"
+    },
+    {
+        "function": "#toMillis",
+        "category": "timezones",
+        "description": "should correctly parse fractional seconds of more than 3 digits, and truncate to millis",
+        "expr": "$toMillis('2026-04-08T19:05:04.01987', '[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01].[f1]') ~> $fromMillis() ",
+        "data": {},
+        "result": "2026-04-08T19:05:04.019Z"
     }
 ]

--- a/testdata/groups/joins/library-joins.json
+++ b/testdata/groups/joins/library-joins.json
@@ -196,5 +196,25 @@
                 "customer": "10003"
             }
         ]
+    },
+    {
+        "expr-file": "library-joins011.jsonata",
+        "dataset": "library",
+        "bindings": {},
+        "result": {
+            "Joe Doe": [
+                "Structure and Interpretation of Computer Programs"
+            ],
+            "Jason Arthur": [
+                "Compilers: Principles, Techniques, and Tools",
+                "Structure and Interpretation of Computer Programs"
+            ]
+        }
+    },
+    {
+        "expr-file": "library-joins012.jsonata",
+        "dataset": "library",
+        "bindings": {},
+        "result": {}
     }
 ]

--- a/testdata/groups/joins/library-joins011.jsonata
+++ b/testdata/groups/joins/library-joins011.jsonata
@@ -1,0 +1,3 @@
+library.loans@$L.books@$B[$L.isbn=$B.isbn].customers[$L.customer=id]{
+  name: $B.title[]
+}

--- a/testdata/groups/joins/library-joins012.jsonata
+++ b/testdata/groups/joins/library-joins012.jsonata
@@ -1,0 +1,3 @@
+library.loans@$L.books@$B[$L.isbn=$B.isbn].customers[$L.customer='not found']{
+  name: $B.title[]
+}


### PR DESCRIPTION
## Summary

- Fixed two behavioral gaps found while refreshing against the official jsonata-js v2.2.2 test suite:
  - `$contains(str, undefined)` now returns undefined instead of raising `T0410`
  - An empty tuple-group join (e.g. a join filtered to zero matches) now returns `{}` instead of undefined, matching upstream's "correctly handle empty joins" fix
- Refreshed `testdata/` with the missing v2.2.2 cases: coalescing/default-operator array-predicate cases, `$each` on an empty object, `$toMillis` fractional-second truncation, and the two new empty-join cases
- Added `Compile` options `WithStack`, `WithTimeout`, and `WithSequence`, matching jsonata-js's `stack`/`timeout`/`sequence` guardrails (errors `D1011`/`D1012`/`D2015`); all are opt-in and existing defaults are unchanged
- Extended the sequence guardrail to `$map`, `$filter`, `$each`, wildcard (`*`), and descendant (`**`) — not just the range operator and `$append`
- Compressed the README benchmark tables into a single table per metric category and dropped the RPC-transport column
- Bumped package version to 0.3.1

## Test plan

- `go test ./...` passes (all suites, including 7 new `testdata/` cases and the new `guardrails_test.go`)
- `golangci-lint run` clean
- Verified each new guardrail-coverage vector manually (`$map`, `$filter`, `$each`, `*`, `**`) before adding regression tests