### PR TITLE
Auto-map arrays in the byte fast path; add custom envs

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -3,6 +3,8 @@ package gnata_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/recolabs/gnata"
@@ -76,6 +78,62 @@ func BenchmarkEvalBytes(b *testing.B) {
 		if err != nil {
 			b.Logf("skip %q: %v", exprStr, err)
 			continue
+		}
+		b.Run(exprStr, func(b *testing.B) {
+			b.SetBytes(int64(len(rawData)))
+			b.ReportAllocs()
+			for range b.N {
+				if _, err := expr.EvalBytes(context.Background(), rawData); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+// wideArraysData builds a document with two nested array boundaries
+// (Order -> Product), large enough that a regression back to full-document
+// decoding shows up clearly in both timing and alloc count — the small
+// benchData fixture above is too tiny for that delta to be obvious.
+func wideArraysData(orders, products int) []byte {
+	var sb strings.Builder
+	sb.WriteString(`{"Account":{"Order":[`)
+	for i := range orders {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		fmt.Fprintf(&sb, `{"OrderID":"o%d","Product":[`, i)
+		for j := range products {
+			if j > 0 {
+				sb.WriteString(",")
+			}
+			fmt.Fprintf(&sb, `{"SKU":"sku-%d-%d","UnitPrice":%d.5}`, i, j, j)
+		}
+		sb.WriteString("]}")
+	}
+	sb.WriteString("]}}")
+	return []byte(sb.String())
+}
+
+var wideArraysExprs = []string{
+	"Account.Order.Product.SKU",
+	"$sum(Account.Order.Product.UnitPrice)",
+	`Account.Order.Product.SKU = "sku-19-4"`,
+	`$exists(Account.Order.Product.SKU)`,
+	`$contains(Account.Order.Product.SKU, "sku-19-4")`,
+}
+
+// BenchmarkEvalBytes_WideArrays exercises EvalBytes on expressions whose path
+// crosses two array boundaries before reaching the target field. These stay
+// on the gjson fast path (no full-document decode) as of the walker added in
+// path_bytes.go; regressing back to a decode fallback here should show up as
+// a large jump in both ns/op and allocs/op.
+func BenchmarkEvalBytes_WideArrays(b *testing.B) {
+	rawData := json.RawMessage(wideArraysData(20, 5))
+	for _, exprStr := range wideArraysExprs {
+		expr, err := gnata.Compile(exprStr)
+		if err != nil {
+			b.Fatalf("compile %q: %v", exprStr, err)
 		}
 		b.Run(exprStr, func(b *testing.B) {
 			b.SetBytes(int64(len(rawData)))

--- a/comparison_bytes_test.go
+++ b/comparison_bytes_test.go
@@ -1,0 +1,156 @@
+package gnata_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/recolabs/gnata"
+)
+
+const comparisonBytesTestData = `{
+	"Account": {
+		"Order": [
+			{"OrderID": "order103", "Product": [
+				{"SKU": "a"},
+				{"SKU": "b"}
+			]},
+			{"OrderID": "order104", "Product": [
+				{"SKU": "c"}
+			]},
+			{"OrderID": "order105", "Product": []}
+		]
+	}
+}`
+
+func TestEvalBytes_ComparisonAcrossArrays_MatchesEval(t *testing.T) {
+	testCases := []struct {
+		desc string
+		expr string
+	}{
+		{desc: "equals a value present in the sequence", expr: `Account.Order.Product.SKU = "a"`},
+		{desc: "not-equals a value present in the sequence", expr: `Account.Order.Product.SKU != "a"`},
+		{desc: "equals a value absent from the sequence", expr: `Account.Order.Product.SKU = "zzz"`},
+		{desc: "not-equals a value absent from the sequence", expr: `Account.Order.Product.SKU != "zzz"`},
+		{desc: "equals against a genuinely undefined path", expr: `Account.Order.Missing.SKU = "a"`},
+		{desc: "not-equals against a genuinely undefined path", expr: `Account.Order.Missing.SKU != "a"`},
+		{desc: "single array boundary equals", expr: `Account.Order.OrderID = "order103"`},
+		{desc: "single array boundary not-equals", expr: `Account.Order.OrderID != "order103"`},
+		{desc: "no arrays at all", expr: `Account.Order[0].OrderID = "order103"`},
+	}
+
+	rawData := json.RawMessage(comparisonBytesTestData)
+	var decoded any
+	if err := json.Unmarshal(rawData, &decoded); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			expr, err := gnata.Compile(tC.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", tC.expr, err)
+			}
+
+			wantResult, wantErr := expr.Eval(context.Background(), decoded)
+			gotResult, gotErr := expr.EvalBytes(context.Background(), rawData)
+
+			if (wantErr == nil) != (gotErr == nil) {
+				t.Fatalf("EvalBytes err = %v, Eval err = %v", gotErr, wantErr)
+			}
+			if !reflect.DeepEqual(gotResult, wantResult) {
+				t.Fatalf("EvalBytes(%q) = %#v, want %#v (from Eval)", tC.expr, gotResult, wantResult)
+			}
+		})
+	}
+}
+
+func TestEvalBytes_ExistsContainsAcrossArrays_MatchesEval(t *testing.T) {
+	testCases := []struct {
+		desc string
+		expr string
+	}{
+		{desc: "exists across two array boundaries, present", expr: `$exists(Account.Order.Product.SKU)`},
+		{desc: "exists across two array boundaries, absent", expr: `$exists(Account.Order.Missing.SKU)`},
+		{desc: "contains across two array boundaries, match", expr: `$contains(Account.Order.Product.SKU, "a")`},
+		{desc: "contains across two array boundaries, no match", expr: `$contains(Account.Order.Product.SKU, "zzz")`},
+	}
+
+	rawData := json.RawMessage(comparisonBytesTestData)
+	var decoded any
+	if err := json.Unmarshal(rawData, &decoded); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			expr, err := gnata.Compile(tC.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", tC.expr, err)
+			}
+
+			wantResult, wantErr := expr.Eval(context.Background(), decoded)
+			gotResult, gotErr := expr.EvalBytes(context.Background(), rawData)
+
+			if (wantErr == nil) != (gotErr == nil) {
+				t.Fatalf("EvalBytes err = %v, Eval err = %v", gotErr, wantErr)
+			}
+			if !reflect.DeepEqual(gotResult, wantResult) {
+				t.Fatalf("EvalBytes(%q) = %#v, want %#v (from Eval)", tC.expr, gotResult, wantResult)
+			}
+		})
+	}
+}
+
+func TestEvalMap_ArrayAutoMap_MatchesEval(t *testing.T) {
+	testCases := []struct {
+		desc string
+		expr string
+	}{
+		{desc: "pure path across two array boundaries", expr: "Account.Order.Product.SKU"},
+		{desc: "sum-shaped aggregate across two array boundaries", expr: "$count(Account.Order.Product.SKU)"},
+		{desc: "comparison across two array boundaries", expr: `Account.Order.Product.SKU = "a"`},
+		{desc: "exists across two array boundaries", expr: `$exists(Account.Order.Product.SKU)`},
+		{desc: "contains across two array boundaries", expr: `$contains(Account.Order.Product.SKU, "a")`},
+	}
+
+	var decoded any
+	if err := json.Unmarshal([]byte(comparisonBytesTestData), &decoded); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	accountValue := decoded.(map[string]any)["Account"]
+	mapData := map[string]json.RawMessage{
+		"Account": mustMarshal(t, accountValue),
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			expr, err := gnata.Compile(tC.expr)
+			if err != nil {
+				t.Fatalf("Compile(%q): %v", tC.expr, err)
+			}
+
+			wantResult, wantErr := expr.Eval(context.Background(), decoded)
+			gotResult, gotErr := expr.EvalMap(context.Background(), mapData)
+
+			if (wantErr == nil) != (gotErr == nil) {
+				t.Fatalf("EvalMap err = %v, Eval err = %v", gotErr, wantErr)
+			}
+			want := gnata.NormalizeValue(wantResult)
+			got := gnata.NormalizeValue(gotResult)
+			if !reflect.DeepEqual(got, want) {
+				t.Fatalf("EvalMap(%q) = %#v, want %#v (from Eval)", tC.expr, got, want)
+			}
+		})
+	}
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}

--- a/evaluator_test.go
+++ b/evaluator_test.go
@@ -166,6 +166,30 @@ func TestEvalLambda(t *testing.T) {
 	}
 }
 
+// TestEvalManyBindings forces a single environment past the point where it
+// must switch from small inline storage to a map: each of these binds more
+// than a couple of names into one scope (call-site "$" plus several lambda
+// params or block variables), which needs to work identically to binding
+// just one or two.
+func TestEvalManyBindings(t *testing.T) {
+	for _, tC := range []struct {
+		desc string
+		expr string
+		want any
+	}{
+		{"three lambda params", "function($a, $b, $c){$a+$b+$c}(1,2,3)", float64(6)},
+		{"five lambda params", "function($a,$b,$c,$d,$e){$a+$b+$c+$d+$e}(1,2,3,4,5)", float64(15)},
+		{"four sequential block bindings", "($a:=1; $b:=2; $c:=3; $d:=4; $a+$b+$c+$d)", float64(10)},
+		{"rebind an existing name after overflow", "($a:=1; $b:=2; $c:=3; $a:=10; $a+$b+$c)", float64(15)},
+	} {
+		t.Run(tC.desc, func(t *testing.T) {
+			if got := evalExpr(t, tC.expr, nil); !gnata.DeepEqual(got, tC.want) {
+				t.Fatalf("got %v, want %v", got, tC.want)
+			}
+		})
+	}
+}
+
 func TestEvalIn(t *testing.T) {
 	for _, tC := range []struct {
 		desc string

--- a/func_fast.go
+++ b/func_fast.go
@@ -74,15 +74,131 @@ var funcFastHandlers = map[parser.FuncFastKind]funcFastHandler{
 
 func evalFunc(f *parser.FuncFastPath, data json.RawMessage, mapData map[string]json.RawMessage) (result any, handled bool, err error) {
 	r := resolveGjsonPath(data, mapData, f.Path)
-	if !r.Exists() {
-		// Fall through to full evaluator — gjson doesn't auto-map through
-		// arrays, so the path might still resolve via the AST walker.
+	if r.Exists() {
+		if h, ok := funcFastHandlers[f.Kind]; ok {
+			return h(&r, f)
+		}
 		return nil, false, nil
 	}
-	if h, ok := funcFastHandlers[f.Kind]; ok {
-		return h(&r, f)
+	// A single dotted-path lookup doesn't auto-map through arrays. Walk the
+	// path step-by-step so an array anywhere in the chain still avoids a
+	// full document decode, for the kinds whose semantics over a resolved
+	// sequence are unambiguous: $exists just needs definedness, the numeric
+	// aggregates and $contains already auto-map over a sequence in the
+	// full evaluator (see their non-walked handlers above). The remaining
+	// kinds (string/boolean coercions, $keys, $distinct, etc.) are left to
+	// the full evaluator: their behavior over a multi-element sequence isn't
+	// a simple per-element reduction, so walking them here would risk a
+	// result that silently disagrees with the AST.
+	if len(f.PathSteps) == 0 {
+		return nil, false, nil
+	}
+	if f.Kind == parser.FuncFastExists {
+		exists := pathExistsWalked(f, data, mapData)
+		return exists, true, nil
+	}
+	values, ok := walkedValues(f, data, mapData)
+	if !ok {
+		return nil, false, nil
+	}
+	//nolint:exhaustive // only the aggregate and contains kinds are handled; other kinds fall through to the (nil, false, nil) fallback below
+	switch f.Kind {
+	case parser.FuncFastSum, parser.FuncFastCount, parser.FuncFastMax, parser.FuncFastMin, parser.FuncFastAverage:
+		if aggResult, aggOK := aggregateFastValues(f.Kind, values); aggOK {
+			return aggResult, true, nil
+		}
+	case parser.FuncFastContains:
+		return containsAnyValue(values, f.StrArg), true, nil
 	}
 	return nil, false, nil
+}
+
+// walkedValues resolves f's primary-argument path across array boundaries,
+// against whichever of data / mapData the caller has available.
+func walkedValues(f *parser.FuncFastPath, data json.RawMessage, mapData map[string]json.RawMessage) ([]gjson.Result, bool) {
+	if data != nil {
+		return walkPureStepsValues(f.PathSteps, data)
+	}
+	if mapData != nil {
+		return walkPureStepsMapValues(f.PathSteps, mapData)
+	}
+	return nil, false
+}
+
+// pathExistsWalked reports whether f's path resolves to a defined value once
+// array boundaries are accounted for. The walker's "cannot resolve" outcome
+// is exactly JSONata's undefined for a pure field-name chain, so this needs
+// no full-evaluator fallback in either direction.
+func pathExistsWalked(f *parser.FuncFastPath, data json.RawMessage, mapData map[string]json.RawMessage) bool {
+	_, ok := walkedValues(f, data, mapData)
+	return ok
+}
+
+// containsAnyValue reports whether any string element of values contains
+// substr, matching $contains's existing any-match semantics over a sequence.
+func containsAnyValue(values []gjson.Result, substr string) bool {
+	for _, v := range values {
+		if v.Type == gjson.String && strings.Contains(v.Str, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// aggregateFastValues computes a numeric aggregate fast path over an
+// already-resolved slice of gjson values. Returns (nil, false) when the kind
+// isn't a supported aggregate or an element isn't numeric.
+func aggregateFastValues(kind parser.FuncFastKind, values []gjson.Result) (any, bool) {
+	if kind == parser.FuncFastCount {
+		return float64(len(values)), true
+	}
+	nums, ok := collectNumbersFrom(values)
+	if !ok {
+		return nil, false
+	}
+	//nolint:exhaustive // Count is already handled above; only the remaining numeric kinds reach here
+	switch kind {
+	case parser.FuncFastSum:
+		var sum float64
+		for _, n := range nums {
+			sum += n
+		}
+		return sum, true
+	case parser.FuncFastAverage:
+		if len(nums) == 0 {
+			return nil, false
+		}
+		var sum float64
+		for _, n := range nums {
+			sum += n
+		}
+		return sum / float64(len(nums)), true
+	case parser.FuncFastMax:
+		if len(nums) == 0 {
+			return nil, true
+		}
+		return slices.Max(nums), true
+	case parser.FuncFastMin:
+		if len(nums) == 0 {
+			return nil, true
+		}
+		return slices.Min(nums), true
+	default:
+		return nil, false
+	}
+}
+
+// collectNumbersFrom extracts numeric values from an already-collected slice
+// of gjson results. Returns (nil, false) if any element isn't a number.
+func collectNumbersFrom(values []gjson.Result) ([]float64, bool) {
+	nums := make([]float64, 0, len(values))
+	for _, v := range values {
+		if v.Type != gjson.Number {
+			return nil, false
+		}
+		nums = append(nums, v.Float())
+	}
+	return nums, true
 }
 
 func evalFuncExists(_ *gjson.Result, _ *parser.FuncFastPath) (result any, handled bool, err error) {

--- a/gnata.go
+++ b/gnata.go
@@ -31,6 +31,10 @@ type Expression struct {
 	// fastPath and paths cover pure-path expressions (e.g. "Account.Name").
 	fastPath bool
 	paths    []string
+	// pathSteps holds the un-escaped field names making up paths[0], used to
+	// walk the path step-by-step (auto-mapping through arrays) when the
+	// single dotted-path gjson lookup below can't resolve it directly.
+	pathSteps []string
 	// cmpFast covers simple path-vs-literal comparisons (e.g. `a.b = "x"`).
 	// Non-nil when the expression qualifies; nil otherwise.
 	cmpFast *parser.ComparisonFastPath
@@ -108,6 +112,7 @@ func Compile(expr string, opts ...Option) (*Expression, error) {
 		ast:        ast,
 		fastPath:   fp.IsFastPath,
 		paths:      fp.GJSONPaths,
+		pathSteps:  fp.PathSteps,
 		cmpFast:    fp.CmpFast,
 		funcFast:   fp.FuncFast,
 		guardrails: g,
@@ -274,29 +279,77 @@ func (e *Expression) Eval(ctx context.Context, data any) (result any, err error)
 	return e.evalCore(ctx, data, builtinEnv, nil)
 }
 
+// tryFastPathBytes attempts the pure-path (including the array-crossing
+// walker) and comparison gjson tiers, against either raw bytes or a
+// pre-destructured map (exactly one of data / mapData should be non-nil,
+// mirroring resolveGjsonPath). Neither tier can ever name a function, so
+// this is safe to share across every EvalBytes*/EvalMap variant regardless
+// of which vars or custom environment the caller passed — including callers
+// whose custom environment shadows a builtin name. handled is false when
+// neither tier could resolve the expression.
+func (e *Expression) tryFastPathBytes(data json.RawMessage, mapData map[string]json.RawMessage) (result any, handled bool, err error) {
+	if e.fastPath && len(e.paths) == 1 {
+		if res := resolveGjsonPath(data, mapData, e.paths[0]); res.Exists() {
+			return gjsonValueToAny(&res), true, nil
+		}
+		var v any
+		var ok bool
+		switch {
+		case data != nil:
+			v, ok = walkPureStepsBytes(e.pathSteps, data)
+		case mapData != nil:
+			v, ok = walkPureStepsMapBytes(e.pathSteps, mapData)
+		}
+		if ok {
+			return v, true, nil
+		}
+		// The walker couldn't resolve the path either — fall through to the
+		// full evaluator.
+	}
+	if e.cmpFast != nil {
+		if res, ok, evalErr := evalComparison(e.cmpFast, data, mapData); ok || evalErr != nil {
+			return res, true, evalErr
+		}
+	}
+	return nil, false, nil
+}
+
+// tryFuncFastBytes attempts the built-in-function fast path, against either
+// raw bytes or a pre-destructured map. Unlike tryFastPathBytes, this
+// dispatches purely on the function's source-text name (parser.FuncFastKind),
+// with no reference to which environment the caller actually passed — so it
+// is only safe for callers that always evaluate against the standard
+// builtinEnv (EvalBytes, EvalBytesWithVars, EvalMap). A caller-supplied
+// custom environment can register a function under a name that collides
+// with a fast-path-eligible builtin (e.g. "sum", "exists", "contains");
+// calling this tier for such a caller would silently run the builtin
+// instead of the caller's override. EvalBytesWithCustomFuncs and
+// EvalBytesWithCustomEnvironmentAndVars must not call this — they fall
+// straight through to the full evaluator for function-fast expressions,
+// which correctly consults the caller's environment.
+func (e *Expression) tryFuncFastBytes(data json.RawMessage, mapData map[string]json.RawMessage) (result any, handled bool, err error) {
+	if e.funcFast != nil {
+		if res, ok, evalErr := evalFunc(e.funcFast, data, mapData); ok || evalErr != nil {
+			return res, true, evalErr
+		}
+	}
+	return nil, false, nil
+}
+
 // EvalBytes evaluates the expression against raw JSON bytes.
 //
 //   - Pure-path fast path: zero-copy GJSON extraction (e.g. "Account.Name").
+//     When the path crosses one or more arrays (e.g. "Account.Order.Product.Price"),
+//     a step-by-step gjson walk auto-maps through them without decoding the document.
 //   - Comparison fast path: single gjson scan for path-vs-literal comparisons.
 //   - Complex expressions: json.Unmarshal + full AST evaluation.
 func (e *Expression) EvalBytes(ctx context.Context, data json.RawMessage) (result any, err error) {
 	defer recoverEvalPanic(&err)
-	if e.fastPath && len(e.paths) == 1 {
-		if res := gjson.GetBytes(data, e.paths[0]); res.Exists() {
-			return gjsonValueToAny(&res), nil
-		}
-		// gjson couldn't resolve the path — fall through to the full evaluator
-		// which handles auto-mapping through arrays correctly.
+	if res, handled, fastErr := e.tryFastPathBytes(data, nil); handled || fastErr != nil {
+		return res, fastErr
 	}
-	if e.cmpFast != nil {
-		if res, handled, evalErr := evalComparison(e.cmpFast, data, nil); handled || evalErr != nil {
-			return res, evalErr
-		}
-	}
-	if e.funcFast != nil {
-		if res, handled, evalErr := evalFunc(e.funcFast, data, nil); handled || evalErr != nil {
-			return res, evalErr
-		}
+	if res, handled, fastErr := e.tryFuncFastBytes(data, nil); handled || fastErr != nil {
+		return res, fastErr
 	}
 	v, err := evaluator.DecodeJSON(data)
 	if err != nil {
@@ -310,20 +363,11 @@ func (e *Expression) EvalBytes(ctx context.Context, data json.RawMessage) (resul
 // making it ideal for pre-destructured data (e.g. database columns, form fields).
 func (e *Expression) EvalMap(ctx context.Context, data map[string]json.RawMessage) (result any, err error) {
 	defer recoverEvalPanic(&err)
-	if e.fastPath && len(e.paths) == 1 {
-		if res := resolveGjsonPath(nil, data, e.paths[0]); res.Exists() {
-			return gjsonValueToAny(&res), nil
-		}
+	if res, handled, fastErr := e.tryFastPathBytes(nil, data); handled || fastErr != nil {
+		return res, fastErr
 	}
-	if e.cmpFast != nil {
-		if res, handled, evalErr := evalComparison(e.cmpFast, nil, data); handled || evalErr != nil {
-			return res, evalErr
-		}
-	}
-	if e.funcFast != nil {
-		if res, handled, evalErr := evalFunc(e.funcFast, nil, data); handled || evalErr != nil {
-			return res, evalErr
-		}
+	if res, handled, fastErr := e.tryFuncFastBytes(nil, data); handled || fastErr != nil {
+		return res, fastErr
 	}
 	v, err := evaluator.DecodeRawMap(data)
 	if err != nil {
@@ -334,31 +378,70 @@ func (e *Expression) EvalMap(ctx context.Context, data map[string]json.RawMessag
 
 // EvalBytesWithVars evaluates the expression against raw JSON bytes with extra
 // variable bindings. Combines the gjson fast-path cascade from EvalBytes with
-// the variable support from EvalWithVars. Fast-path expressions never reference
-// $variables (excluded at compile time), so the fast-path result is independent
-// of the variable map; only the full-eval fallback uses vars.
+// the variable support from EvalWithVars.
 func (e *Expression) EvalBytesWithVars(ctx context.Context, data json.RawMessage, vars map[string]any) (result any, err error) {
 	defer recoverEvalPanic(&err)
-	if e.fastPath && len(e.paths) == 1 {
-		if res := gjson.GetBytes(data, e.paths[0]); res.Exists() {
-			return gjsonValueToAny(&res), nil
-		}
+	if res, handled, fastErr := e.tryFastPathBytes(data, nil); handled || fastErr != nil {
+		return res, fastErr
 	}
-	if e.cmpFast != nil {
-		if res, handled, evalErr := evalComparison(e.cmpFast, data, nil); handled || evalErr != nil {
-			return res, evalErr
-		}
-	}
-	if e.funcFast != nil {
-		if res, handled, evalErr := evalFunc(e.funcFast, data, nil); handled || evalErr != nil {
-			return res, evalErr
-		}
+	if res, handled, fastErr := e.tryFuncFastBytes(data, nil); handled || fastErr != nil {
+		return res, fastErr
 	}
 	v, err := evaluator.DecodeJSON(data)
 	if err != nil {
 		return nil, err
 	}
 	return e.evalCore(ctx, v, builtinEnv, vars)
+}
+
+// EvalBytesWithCustomFuncs evaluates raw JSON bytes using a custom
+// environment. The env parameter should be created via NewCustomEnv.
+// Combines the pure-path/comparison gjson tiers from EvalBytes with the
+// custom environment support from EvalWithCustomFuncs. Deliberately skips
+// the function fast path (see tryFuncFastBytes): a caller-supplied
+// environment can register a function under a name that shadows a
+// fast-path-eligible builtin, and only the full evaluator consults env for
+// function resolution.
+func (e *Expression) EvalBytesWithCustomFuncs(
+	ctx context.Context, data json.RawMessage, env *evaluator.Environment,
+) (result any, err error) {
+	defer recoverEvalPanic(&err)
+	if res, handled, fastErr := e.tryFastPathBytes(data, nil); handled || fastErr != nil {
+		return res, fastErr
+	}
+	v, err := evaluator.DecodeJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	return e.evalCore(ctx, v, env, nil)
+}
+
+// EvalBytesWithCustomEnvironmentAndVars evaluates raw JSON bytes with a
+// pre-built custom environment and per-call variable bindings. Construct the
+// environment once via NewCustomEnvironment and reuse it across evaluations,
+// same as EvalWithCustomEnvironmentAndVars. Combines the pure-path/comparison
+// gjson tiers from EvalBytes with that decoded-input API's custom-function
+// and $-variable support. Deliberately skips the function fast path — see
+// EvalBytesWithCustomFuncs and tryFuncFastBytes for why.
+func (e *Expression) EvalBytesWithCustomEnvironmentAndVars(
+	ctx context.Context,
+	data json.RawMessage,
+	customEnv *CustomEnvironment,
+	vars map[string]any,
+) (result any, err error) {
+	defer recoverEvalPanic(&err)
+	if res, handled, fastErr := e.tryFastPathBytes(data, nil); handled || fastErr != nil {
+		return res, fastErr
+	}
+	v, err := evaluator.DecodeJSON(data)
+	if err != nil {
+		return nil, err
+	}
+	parent := builtinEnv
+	if customEnv != nil {
+		parent = customEnv.env
+	}
+	return e.evalCore(ctx, v, parent, vars)
 }
 
 // resolveGjsonPath resolves a gjson path from either raw bytes or a pre-decoded map.
@@ -399,30 +482,48 @@ func evalComparison(
 	c *parser.ComparisonFastPath, data json.RawMessage, mapData map[string]json.RawMessage,
 ) (result any, handled bool, err error) {
 	lhs := resolveGjsonPath(data, mapData, c.LHSPath)
-	if !lhs.Exists() {
-		// gjson couldn't resolve the path. This could be because the path is
-		// truly undefined OR because an intermediate element is a JSON array
-		// (gjson doesn't auto-map through arrays, but JSONata does).
-		// Fall back to the full evaluator which handles both cases correctly.
+	if lhs.Exists() {
+		match, ok := matchComparison(&lhs, c)
+		return match, ok, nil
+	}
+	// gjson couldn't resolve the path. This could be because the path is
+	// truly undefined OR because an intermediate element is a JSON array
+	// (gjson doesn't auto-map through arrays, but JSONata does). Walk the
+	// path step-by-step so the array case still avoids a full document decode.
+	if len(c.LHSPathSteps) == 0 {
 		return nil, false, nil
 	}
-
-	if lhs.Type == gjson.JSON {
-		raw := lhs.Raw
-		if raw != "" && raw[0] == '[' {
-			// JSON array: JSONata auto-maps comparisons element-wise.
-			// For null checks we can safely short-circuit (arrays are never null).
-			if c.RHSKind == parser.RHSKindNull {
-				return c.Op == "!=", true, nil
-			}
-			// For all other comparisons, fall back to the full evaluator.
-			return nil, false, nil
-		}
-		// JSON object: never equal to any primitive literal.
+	var values []gjson.Result
+	var ok bool
+	switch {
+	case data != nil:
+		values, ok = walkPureStepsValues(c.LHSPathSteps, data)
+	case mapData != nil:
+		values, ok = walkPureStepsMapValues(c.LHSPathSteps, mapData)
+	}
+	if !ok {
+		return nil, false, nil
+	}
+	if len(values) != 1 {
+		// A resolved sequence — whether flattened to more than one element,
+		// or to zero elements from a field present as an empty array — is
+		// never structurally equal to a scalar literal.
 		return c.Op == "!=", true, nil
 	}
+	match, ok := matchComparison(&values[0], c)
+	return match, ok, nil
+}
 
-	var match bool
+// matchComparison evaluates a single resolved gjson value against a
+// pre-compiled comparison literal. JSON arrays and objects are never equal
+// to a primitive literal regardless of the literal's type; JSONata's
+// equality operator does structural, not any-element, comparison.
+// ok is false only for an unrecognized RHSKind, which never occurs today
+// since the parser only ever produces the four known kinds.
+func matchComparison(lhs *gjson.Result, c *parser.ComparisonFastPath) (match, ok bool) {
+	if lhs.Type == gjson.JSON {
+		return c.Op == "!=", true
+	}
 	switch c.RHSKind {
 	case parser.RHSKindString:
 		match = lhs.Type == gjson.String && lhs.String() == c.RHSString
@@ -444,12 +545,12 @@ func evalComparison(
 	case parser.RHSKindNull:
 		match = lhs.Type == gjson.Null
 	default:
-		return nil, false, nil
+		return false, false
 	}
 	if c.Op == "!=" {
 		match = !match
 	}
-	return match, true, nil
+	return match, true
 }
 
 // gjsonValueToAny converts a gjson.Result to a native Go value.

--- a/gnata_test.go
+++ b/gnata_test.go
@@ -2,6 +2,8 @@ package gnata_test
 
 import (
 	"context"
+	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/recolabs/gnata"
@@ -128,6 +130,104 @@ func TestEvalWithCustomEnvironmentAndVars(t *testing.T) {
 	}
 	if got != "hello world" {
 		t.Fatalf("got %v, want %q", got, "hello world")
+	}
+}
+
+func TestEvalBytesWithCustomFuncs(t *testing.T) {
+	env := gnata.NewCustomEnv(map[string]gnata.CustomFunc{
+		"double": func(args []any, _ any) (any, error) {
+			n, err := args[0].(json.Number).Float64()
+			if err != nil {
+				return nil, err
+			}
+			return n * 2, nil
+		},
+	})
+	compiled, err := gnata.Compile(`$double(value)`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := compiled.EvalBytesWithCustomFuncs(context.Background(), []byte(`{"value": 21}`), env)
+	if err != nil {
+		t.Fatalf("EvalBytesWithCustomFuncs: %v", err)
+	}
+	if got != float64(42) {
+		t.Fatalf("got %v, want 42", got)
+	}
+}
+
+func TestEvalBytesWithCustomEnvironmentAndVars(t *testing.T) {
+	env := gnata.NewCustomEnvironment(map[string]gnata.CustomFunc{
+		"greet": func(args []any, _ any) (any, error) {
+			return "hello " + args[0].(string), nil
+		},
+	})
+	compiled, err := gnata.Compile(`$greet($who)`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	got, err := compiled.EvalBytesWithCustomEnvironmentAndVars(
+		context.Background(), []byte(`{}`), env, map[string]any{"who": "world"},
+	)
+	if err != nil {
+		t.Fatalf("EvalBytesWithCustomEnvironmentAndVars: %v", err)
+	}
+	if got != "hello world" {
+		t.Fatalf("got %v, want %q", got, "hello world")
+	}
+}
+
+// TestEvalBytesWithCustomFuncs_OverridesShadowedBuiltin verifies that a
+// custom function registered under a name that collides with a fast-path
+// builtin (here "sum") actually runs instead of the builtin gjson-based
+// implementation. The function fast path dispatches purely by source-text
+// name with no reference to the caller's environment, so EvalBytesWithCustomFuncs
+// must skip that tier entirely — otherwise the override would be silently
+// ignored whenever the fast path fires.
+func TestEvalBytesWithCustomFuncs_OverridesShadowedBuiltin(t *testing.T) {
+	env := gnata.NewCustomEnv(map[string]gnata.CustomFunc{
+		"sum": func(_ []any, _ any) (any, error) {
+			return "overridden", nil
+		},
+	})
+	compiled, err := gnata.Compile(`$sum(nums)`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if !compiled.IsFuncFastPath() {
+		t.Fatal("expected IsFuncFastPath() == true so this test actually exercises the shadowing risk")
+	}
+	got, err := compiled.EvalBytesWithCustomFuncs(context.Background(), []byte(`{"nums": [1, 2, 3]}`), env)
+	if err != nil {
+		t.Fatalf("EvalBytesWithCustomFuncs: %v", err)
+	}
+	if got != "overridden" {
+		t.Fatalf("got %v, want %q (custom function override was ignored, builtin $sum ran instead)", got, "overridden")
+	}
+}
+
+// TestEvalBytesWithCustomFuncs_FastPathUnaffected checks that a pure-path
+// fast-path expression still resolves via gjson (not the custom env / decode
+// fallback) when evaluated through the new bytes+custom-env API — the fast
+// path never references custom functions, so it must behave identically
+// regardless of which environment the caller supplies.
+func TestEvalBytesWithCustomFuncs_FastPathUnaffected(t *testing.T) {
+	env := gnata.NewCustomEnv(nil)
+	compiled, err := gnata.Compile(`Account.Order.Product.SKU`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if !compiled.IsFastPath() {
+		t.Fatal("expected IsFastPath() == true")
+	}
+	data := []byte(`{"Account":{"Order":[{"Product":[{"SKU":"a"},{"SKU":"b"}]}]}}`)
+	got, err := compiled.EvalBytesWithCustomFuncs(context.Background(), data, env)
+	if err != nil {
+		t.Fatalf("EvalBytesWithCustomFuncs: %v", err)
+	}
+	want := []any{"a", "b"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/evaluator/env.go
+++ b/internal/evaluator/env.go
@@ -12,6 +12,12 @@ import (
 // Matches the JSONata reference implementation's default.
 const defaultMaxCallDepth = 100
 
+// inlineBindingCap is the number of variable bindings an Environment stores
+// inline before spilling to a map. Most child environments created per-eval
+// bind only "$" (and occasionally one more, e.g. a lambda parameter or a
+// path index variable), so this avoids a map allocation on the common path.
+const inlineBindingCap = 2
+
 // callCounter tracks the current recursive call depth across all child environments.
 // A pointer is shared so all nested envs increment/decrement the same counter.
 type callCounter struct {
@@ -22,26 +28,39 @@ type callCounter struct {
 	maxSequence  int  // 0 = unlimited; guardrail set via WithSequence (error D2015)
 }
 
+// binding is one name/value pair stored inline on an Environment.
+type binding struct {
+	name  string
+	value any
+}
+
 // Environment holds variable bindings for an evaluation context.
 // It forms a linked chain for lexical scoping.
+//
+// Bindings are stored in the inline array until more than inlineBindingCap
+// accumulate, at which point they're moved into bindings (a lazily-allocated
+// map) and inline is no longer consulted. This keeps the common per-eval
+// child environment (bound to "$" and little else) allocation-free beyond
+// the Environment struct itself.
 type Environment struct {
 	parent   *Environment
-	bindings map[string]any
-	calls    *callCounter // shared call-depth counter; nil inherits from parent
+	inline   [inlineBindingCap]binding
+	inlineN  int
+	bindings map[string]any // nil until inline overflows
+	calls    *callCounter   // shared call-depth counter; nil inherits from parent
 	ctx      context.Context
 }
 
 // NewEnvironment creates a root environment with no bindings.
 func NewEnvironment() *Environment {
 	return &Environment{
-		bindings: make(map[string]any),
-		calls:    &callCounter{max: defaultMaxCallDepth},
+		calls: &callCounter{max: defaultMaxCallDepth},
 	}
 }
 
 // NewChildEnvironment creates a child scope inheriting from parent.
 func NewChildEnvironment(parent *Environment) *Environment {
-	env := &Environment{parent: parent, bindings: make(map[string]any)}
+	env := &Environment{parent: parent}
 	if parent != nil {
 		env.calls = parent.callCounter()
 	}
@@ -61,7 +80,29 @@ func (e *Environment) callCounter() *callCounter {
 
 // Bind sets a variable in this environment.
 func (e *Environment) Bind(name string, value any) {
+	if e.bindings != nil {
+		e.bindings[name] = value
+		return
+	}
+	for i := range e.inlineN {
+		if e.inline[i].name == name {
+			e.inline[i].value = value
+			return
+		}
+	}
+	if e.inlineN < inlineBindingCap {
+		e.inline[e.inlineN] = binding{name: name, value: value}
+		e.inlineN++
+		return
+	}
+	// Overflow: spill the inline bindings into a map and clear inline state
+	// so later lookups only need to check one representation.
+	e.bindings = make(map[string]any, inlineBindingCap+1)
+	for i := range e.inlineN {
+		e.bindings[e.inline[i].name] = e.inline[i].value
+	}
 	e.bindings[name] = value
+	e.inlineN = 0
 }
 
 // Parent returns the parent environment (nil for root environments).
@@ -72,7 +113,7 @@ func (e *Environment) Parent() *Environment {
 // Lookup looks up a variable, walking the parent chain.
 // Returns (nil, false) if not found.
 func (e *Environment) Lookup(name string) (any, bool) {
-	if v, ok := e.bindings[name]; ok {
+	if v, ok := e.LookupDirect(name); ok {
 		return v, true
 	}
 	if e.parent != nil {
@@ -87,7 +128,7 @@ func (e *Environment) Lookup(name string) (any, bool) {
 // parent of the binding's environment, not the parent of the starting env.
 // Returns (nil, nil, false) if not found.
 func (e *Environment) LookupWithEnv(name string) (any, *Environment, bool) {
-	if v, ok := e.bindings[name]; ok {
+	if v, ok := e.LookupDirect(name); ok {
 		return v, e, true
 	}
 	if e.parent != nil {
@@ -145,16 +186,21 @@ func (e *Environment) CheckSequence(n int) error {
 	return nil
 }
 
-// Clone creates a shallow copy of the environment, duplicating the bindings map
+// Clone creates a shallow copy of the environment, duplicating its bindings
 // but sharing the same parent and call counter references.
 func (e *Environment) Clone() *Environment {
 	child := &Environment{
-		bindings: make(map[string]any, len(e.bindings)),
-		parent:   e.parent,
-		calls:    e.calls,
-		ctx:      e.ctx,
+		parent: e.parent,
+		calls:  e.calls,
+		ctx:    e.ctx,
 	}
-	maps.Copy(child.bindings, e.bindings)
+	if e.bindings != nil {
+		child.bindings = make(map[string]any, len(e.bindings))
+		maps.Copy(child.bindings, e.bindings)
+		return child
+	}
+	child.inline = e.inline
+	child.inlineN = e.inlineN
 	return child
 }
 
@@ -179,15 +225,29 @@ func (e *Environment) SetContext(ctx context.Context) {
 
 // Range iterates over the bindings in this environment (not parents).
 func (e *Environment) Range(fn func(name string, val any)) {
-	for k, v := range e.bindings {
-		fn(k, v)
+	if e.bindings != nil {
+		for k, v := range e.bindings {
+			fn(k, v)
+		}
+		return
+	}
+	for i := range e.inlineN {
+		fn(e.inline[i].name, e.inline[i].value)
 	}
 }
 
 // LookupDirect checks only the direct bindings (no parent chain walk).
 func (e *Environment) LookupDirect(name string) (any, bool) {
-	v, ok := e.bindings[name]
-	return v, ok
+	if e.bindings != nil {
+		v, ok := e.bindings[name]
+		return v, ok
+	}
+	for i := range e.inlineN {
+		if e.inline[i].name == name {
+			return e.inline[i].value, true
+		}
+	}
+	return nil, false
 }
 
 // BuiltinFunction is a native Go function implementing a JSONata built-in.

--- a/internal/evaluator/eval_helpers.go
+++ b/internal/evaluator/eval_helpers.go
@@ -238,6 +238,11 @@ func evalVariable(node *parser.Node, input any, env *Environment) (any, error) {
 	return val, nil
 }
 
+// evalName's array-mapping semantics (flatten one level per step, track
+// whether the field was ever found to distinguish "undefined" from "found
+// as an empty array", singleton-collapse a single match) are mirrored by
+// path_bytes.go's walkPureSteps/stepArray for the gjson-based fast path.
+// Keep the two in sync: a change here needs the matching change there.
 func evalName(node *parser.Node, input any, _ *Environment) (any, error) {
 	switch v := input.(type) {
 	case *OrderedMap:

--- a/internal/parser/analysis.go
+++ b/internal/parser/analysis.go
@@ -86,13 +86,14 @@ type (
 	// Both fields are populated at Compile() time so that EvalBytes can evaluate
 	// the expression with a single gjson scan — no json.Unmarshal, no AST walk.
 	ComparisonFastPath struct {
-		LHSPath      string  // gjson path string for the left-hand operand
-		Op           string  // "=" or "!="
-		RHSKind      rhsKind // type of the right-hand literal
-		RHSString    string  // valid when RHSKind == RHSKindString
-		RHSNumber    float64 // valid when RHSKind == RHSKindNumber
-		RHSNumberStr string  // pre-formatted RHSNumber for fast integer comparison
-		RHSBool      bool    // valid when RHSKind == RHSKindBool
+		LHSPath      string   // gjson path string for the left-hand operand
+		LHSPathSteps []string // un-escaped field names making up LHSPath, one per path step
+		Op           string   // "=" or "!="
+		RHSKind      rhsKind  // type of the right-hand literal
+		RHSString    string   // valid when RHSKind == RHSKindString
+		RHSNumber    float64  // valid when RHSKind == RHSKindNumber
+		RHSNumberStr string   // pre-formatted RHSNumber for fast integer comparison
+		RHSBool      bool     // valid when RHSKind == RHSKindBool
 	}
 
 	// FuncFastPath holds a pre-analyzed function call of the form $func(pure-path)
@@ -100,9 +101,10 @@ type (
 	// Populated at Compile() time so that EvalBytes can evaluate the expression
 	// with a single gjson scan — no json.Unmarshal, no AST walk.
 	FuncFastPath struct {
-		Kind   FuncFastKind
-		Path   string // gjson path for the primary argument
-		StrArg string // second string literal for $contains; empty for all others
+		Kind      FuncFastKind
+		Path      string   // gjson path for the primary argument
+		PathSteps []string // un-escaped field names making up Path, one per path step
+		StrArg    string   // second string literal for $contains; empty for all others
 	}
 
 	// fastPathResult holds the result of analyzing an expression for fast-path eligibility.
@@ -113,6 +115,9 @@ type (
 		// GJSONPaths is the set of GJSON path strings that this expression reads.
 		// Only populated when IsFastPath is true.
 		GJSONPaths []string
+		// PathSteps holds the un-escaped field names making up GJSONPaths[0], one
+		// per path step. Only populated when IsFastPath is true.
+		PathSteps []string
 		// CmpFast is non-nil when the expression is a simple path-vs-literal comparison
 		// that can be evaluated with a single gjson scan.
 		CmpFast *ComparisonFastPath
@@ -150,7 +155,7 @@ type (
 func AnalyzeFastPath(node *Node) fastPathResult {
 	paths, ok := collectPaths(node)
 	if ok {
-		return fastPathResult{IsFastPath: true, GJSONPaths: paths}
+		return fastPathResult{IsFastPath: true, GJSONPaths: paths, PathSteps: rawStepNames(node)}
 	}
 	if cmp := tryCollectComparison(node); cmp != nil {
 		return fastPathResult{CmpFast: cmp}
@@ -159,6 +164,26 @@ func AnalyzeFastPath(node *Node) fastPathResult {
 		return fastPathResult{FuncFast: fn}
 	}
 	return fastPathResult{IsFastPath: false}
+}
+
+// rawStepNames returns the un-escaped field names of a node already proven
+// fast-path eligible by collectPaths, one entry per path step. Kept separate
+// from collectPaths because that function returns names pre-escaped for a
+// single gjson dotted-path string, which callers doing their own per-step
+// traversal need in their original, un-escaped form.
+func rawStepNames(node *Node) []string {
+	switch node.Type {
+	case NodeName:
+		return []string{node.Value}
+	case NodePath:
+		names := make([]string, len(node.Steps))
+		for i, step := range node.Steps {
+			names[i] = step.Value
+		}
+		return names
+	default:
+		return nil
+	}
 }
 
 // tryCollectFunc returns a FuncFastPath when node is a call to a supported
@@ -186,9 +211,10 @@ func tryCollectFunc(node *Node) *FuncFastPath {
 			return nil
 		}
 		return &FuncFastPath{
-			Kind:   FuncFastContains,
-			Path:   paths[0],
-			StrArg: node.Arguments[1].Value,
+			Kind:      FuncFastContains,
+			Path:      paths[0],
+			PathSteps: rawStepNames(node.Arguments[0]),
+			StrArg:    node.Arguments[1].Value,
 		}
 	}
 
@@ -204,8 +230,9 @@ func tryCollectFunc(node *Node) *FuncFastPath {
 		return nil
 	}
 	return &FuncFastPath{
-		Kind: kind,
-		Path: paths[0],
+		Kind:      kind,
+		Path:      paths[0],
+		PathSteps: rawStepNames(node.Arguments[0]),
 	}
 }
 
@@ -229,26 +256,28 @@ func tryCollectComparison(node *Node) *ComparisonFastPath {
 	}
 	lhsPath := lhsPaths[0]
 
+	lhsSteps := rawStepNames(node.Left)
+
 	switch node.Right.Type {
 	case NodeString:
 		return &ComparisonFastPath{
-			LHSPath: lhsPath, Op: op,
+			LHSPath: lhsPath, LHSPathSteps: lhsSteps, Op: op,
 			RHSKind: RHSKindString, RHSString: node.Right.Value,
 		}
 	case NodeNumber:
 		return &ComparisonFastPath{
-			LHSPath: lhsPath, Op: op,
+			LHSPath: lhsPath, LHSPathSteps: lhsSteps, Op: op,
 			RHSKind: RHSKindNumber, RHSNumber: node.Right.NumVal,
 			RHSNumberStr: strconv.FormatFloat(node.Right.NumVal, 'f', -1, 64),
 		}
 	case NodeValue:
 		switch node.Right.Value {
 		case "true":
-			return &ComparisonFastPath{LHSPath: lhsPath, Op: op, RHSKind: RHSKindBool, RHSBool: true}
+			return &ComparisonFastPath{LHSPath: lhsPath, LHSPathSteps: lhsSteps, Op: op, RHSKind: RHSKindBool, RHSBool: true}
 		case "false":
-			return &ComparisonFastPath{LHSPath: lhsPath, Op: op, RHSKind: RHSKindBool, RHSBool: false}
+			return &ComparisonFastPath{LHSPath: lhsPath, LHSPathSteps: lhsSteps, Op: op, RHSKind: RHSKindBool, RHSBool: false}
 		case "null":
-			return &ComparisonFastPath{LHSPath: lhsPath, Op: op, RHSKind: RHSKindNull}
+			return &ComparisonFastPath{LHSPath: lhsPath, LHSPathSteps: lhsSteps, Op: op, RHSKind: RHSKindNull}
 		}
 	}
 	return nil

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gnata-js",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gnata-js",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.8.0"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnata-js",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Browser JSONata via gnata WASM for backend parity, not a performance optimization",
   "license": "MIT",
   "repository": {

--- a/path_bytes.go
+++ b/path_bytes.go
@@ -1,0 +1,206 @@
+package gnata
+
+import (
+	"encoding/json"
+
+	"github.com/tidwall/gjson"
+)
+
+// walkPureSteps resolves a chain of pure field-name path steps against a
+// gjson document, auto-mapping through arrays at every step exactly like the
+// full evaluator does, without ever unmarshaling the document. Returns
+// (value, false) when the walker cannot represent the result (a step landed
+// on a scalar, or the field is genuinely absent) — the caller should fall
+// back to full evaluation in that case.
+//
+// Mirrors evalName's []any case in internal/evaluator/eval_helpers.go on
+// decoded values — keep the two in sync; see the note on evalName.
+func walkPureSteps(steps []string, root *gjson.Result) (any, bool) {
+	var cur any = *root
+	for _, step := range steps {
+		next, ok := stepValue(step, cur)
+		if !ok {
+			return nil, false
+		}
+		cur = next
+	}
+	return finalizeStepValue(cur), true
+}
+
+func stepValue(step string, cur any) (any, bool) {
+	switch v := cur.(type) {
+	case gjson.Result:
+		return stepSingle(step, &v)
+	case []gjson.Result:
+		return stepArray(step, v)
+	default:
+		return nil, false
+	}
+}
+
+func stepSingle(step string, r *gjson.Result) (any, bool) {
+	switch {
+	case r.IsObject():
+		// A literal-key scan via ForEach, not r.Get(step): Get treats its
+		// argument as a full gjson path expression, where '.', '*', '?',
+		// '#', '|', '!', brackets, and backslash are syntactically
+		// significant. A field name containing any of those (e.g. "a.b")
+		// would otherwise be silently misinterpreted as a nested/wildcard
+		// path instead of the literal key JSONata means. ForEach with an
+		// early exit avoids building the full key/value map just to read
+		// one entry.
+		var val gjson.Result
+		found := false
+		r.ForEach(func(key, value gjson.Result) bool {
+			if key.Str == step {
+				val, found = value, true
+				return false
+			}
+			return true
+		})
+		if !found {
+			return nil, false
+		}
+		return val, true
+	case r.IsArray():
+		return stepArray(step, r.Array())
+	default:
+		return nil, false
+	}
+}
+
+// stepArray applies a field-lookup step across every element of an array,
+// flattening one level of nested-array results into the output — matching
+// JSONata's array auto-mapping semantics.
+func stepArray(step string, arr []gjson.Result) (any, bool) {
+	flat := make([]gjson.Result, 0, len(arr))
+	fieldFound := false
+	for i := range arr {
+		val, ok := stepSingle(step, &arr[i])
+		if !ok {
+			continue
+		}
+		fieldFound = true
+		switch inner := val.(type) {
+		case gjson.Result:
+			if inner.IsArray() {
+				flat = append(flat, inner.Array()...)
+			} else {
+				flat = append(flat, inner)
+			}
+		case []gjson.Result:
+			flat = append(flat, inner...)
+		}
+	}
+	switch {
+	case len(flat) == 0 && fieldFound:
+		return []gjson.Result{}, true
+	case len(flat) == 0:
+		return nil, false
+	case len(flat) == 1:
+		return flat[0], true
+	default:
+		return flat, true
+	}
+}
+
+func finalizeStepValue(cur any) any {
+	switch v := cur.(type) {
+	case gjson.Result:
+		return gjsonValueToAny(&v)
+	case []gjson.Result:
+		out := make([]any, len(v))
+		for i := range v {
+			out[i] = gjsonValueToAny(&v[i])
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
+// walkPureStepsBytes resolves steps against raw JSON bytes. Returns
+// (value, false) when the caller should fall back to full evaluation.
+func walkPureStepsBytes(steps []string, data []byte) (any, bool) {
+	root := gjson.ParseBytes(data)
+	if !root.Exists() {
+		return nil, false
+	}
+	return walkPureSteps(steps, &root)
+}
+
+// walkPureStepsMapBytes resolves steps against a map of top-level field names
+// to raw JSON values (EvalMap's input shape). The first step is an O(1) map
+// lookup by field name; remaining steps walk gjson.Result the same way as
+// walkPureStepsBytes. Returns (value, false) when the caller should fall
+// back to full evaluation.
+func walkPureStepsMapBytes(steps []string, mapData map[string]json.RawMessage) (any, bool) {
+	root, rest, ok := firstStepFromMap(steps, mapData)
+	if !ok {
+		return nil, false
+	}
+	return walkPureSteps(rest, &root)
+}
+
+// walkPureStepsValues resolves steps against raw JSON bytes and returns the
+// leaf values as a []gjson.Result, for callers (aggregate and any-match fast
+// paths) that need to reduce over the raw values themselves rather than a
+// finalized Go value. A single scalar result is returned as a one-element
+// slice; an array-typed result is exploded into its elements. ok is false
+// when the walker cannot represent the result.
+func walkPureStepsValues(steps []string, data []byte) (values []gjson.Result, ok bool) {
+	root := gjson.ParseBytes(data)
+	if !root.Exists() {
+		return nil, false
+	}
+	return walkPureStepsValuesFrom(steps, &root)
+}
+
+// walkPureStepsMapValues is walkPureStepsValues for EvalMap's input shape.
+func walkPureStepsMapValues(steps []string, mapData map[string]json.RawMessage) (values []gjson.Result, ok bool) {
+	root, rest, firstOK := firstStepFromMap(steps, mapData)
+	if !firstOK {
+		return nil, false
+	}
+	return walkPureStepsValuesFrom(rest, &root)
+}
+
+// firstStepFromMap resolves the first path step via an O(1) map lookup,
+// returning the parsed remainder as a gjson.Result root plus the remaining
+// steps to walk from there.
+func firstStepFromMap(steps []string, mapData map[string]json.RawMessage) (root gjson.Result, rest []string, ok bool) {
+	if len(steps) == 0 || mapData == nil {
+		return gjson.Result{}, nil, false
+	}
+	raw, exists := mapData[steps[0]]
+	if !exists {
+		return gjson.Result{}, nil, false
+	}
+	root = gjson.ParseBytes(raw)
+	if !root.Exists() {
+		return gjson.Result{}, nil, false
+	}
+	return root, steps[1:], true
+}
+
+func walkPureStepsValuesFrom(steps []string, root *gjson.Result) (values []gjson.Result, ok bool) {
+	var cur any = *root
+	for _, step := range steps {
+		next, stepOK := stepValue(step, cur)
+		if !stepOK {
+			return nil, false
+		}
+		cur = next
+	}
+	switch v := cur.(type) {
+	case []gjson.Result:
+		return v, true
+	case gjson.Result:
+		if v.IsArray() {
+			return v.Array(), true
+		}
+		return []gjson.Result{v}, true
+	default:
+		return nil, false
+	}
+}

--- a/path_bytes_test.go
+++ b/path_bytes_test.go
@@ -1,0 +1,179 @@
+package gnata_test
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/recolabs/gnata"
+)
+
+const pathBytesTestData = `{
+	"Account": {
+		"Name": "Firefly",
+		"Order": [
+			{"OrderID": "order103", "Product": [
+				{"SKU": "0406654608", "UnitPrice": 68.45},
+				{"SKU": "040657863", "UnitPrice": 107.99}
+			]},
+			{"OrderID": "order104", "Product": [
+				{"SKU": "0406654608", "UnitPrice": 68.45},
+				{"SKU": "0406654603", "UnitPrice": 21.67}
+			]},
+			{"OrderID": "order105", "Product": [], "Note": null},
+			{"OrderID": "order106"}
+		]
+	}
+}`
+
+// evalBytesMatchesEvalCase runs one EvalBytes-vs-Eval differential check,
+// shared by the pure-path and aggregate-fast test suites below (they differ
+// only in which fast-path classifier they assert and the fixture used).
+func evalBytesMatchesEvalCase(t *testing.T, expr string, rawData json.RawMessage, decoded any, wantFastPath func(*gnata.Expression) bool) {
+	t.Helper()
+	compiled, err := gnata.Compile(expr)
+	if err != nil {
+		t.Fatalf("Compile(%q): %v", expr, err)
+	}
+	if !wantFastPath(compiled) {
+		t.Fatalf("Compile(%q): expected the relevant fast-path classifier to be true", expr)
+	}
+
+	wantResult, wantErr := compiled.Eval(context.Background(), decoded)
+	gotResult, gotErr := compiled.EvalBytes(context.Background(), rawData)
+
+	if (wantErr == nil) != (gotErr == nil) {
+		t.Fatalf("EvalBytes err = %v, Eval err = %v", gotErr, wantErr)
+	}
+	want := gnata.NormalizeValue(wantResult)
+	got := gnata.NormalizeValue(gotResult)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("EvalBytes(%q) = %#v, want %#v (from Eval)", expr, got, want)
+	}
+}
+
+func TestEvalBytes_ArrayAutoMap_MatchesEval(t *testing.T) {
+	testCases := []struct {
+		desc string
+		expr string
+	}{
+		{desc: "two array boundaries to scalar leaf", expr: "Account.Order.Product.SKU"},
+		{desc: "two array boundaries to numeric leaf", expr: "Account.Order.Product.UnitPrice"},
+		{desc: "single array boundary", expr: "Account.Order.OrderID"},
+		{desc: "field missing on some elements", expr: "Account.Order.Note"},
+		{desc: "pure path with no arrays", expr: "Account.Name"},
+	}
+
+	rawData := json.RawMessage(pathBytesTestData)
+	var decoded any
+	if err := json.Unmarshal(rawData, &decoded); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			evalBytesMatchesEvalCase(t, tC.expr, rawData, decoded, (*gnata.Expression).IsFastPath)
+		})
+	}
+}
+
+func TestEvalBytes_ArrayAutoMap_NoFullDecode(t *testing.T) {
+	expr, err := gnata.Compile("Account.Order.Product.SKU")
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	rawData := json.RawMessage(pathBytesTestData)
+
+	allocs := testing.AllocsPerRun(20, func() {
+		if _, err := expr.EvalBytes(context.Background(), rawData); err != nil {
+			t.Fatal(err)
+		}
+	})
+	// The full-decode fallback (json.Decoder into *OrderedMap for every
+	// object, plus the AST walk) allocates well over 40 times per call for
+	// this fixture. The array-aware walker should stay far below that.
+	const maxAllocs = 30
+	if allocs > maxAllocs {
+		t.Fatalf("EvalBytes allocated %.1f times per call, want <= %d (full decode likely still happening)", allocs, maxAllocs)
+	}
+}
+
+func TestEvalBytes_AggregateFast_MatchesEval(t *testing.T) {
+	testCases := []struct {
+		desc string
+		expr string
+	}{
+		{desc: "sum across two array boundaries", expr: "$sum(Account.Order.Product.UnitPrice)"},
+		{desc: "count across two array boundaries", expr: "$count(Account.Order.Product.UnitPrice)"},
+		{desc: "max across two array boundaries", expr: "$max(Account.Order.Product.UnitPrice)"},
+		{desc: "min across two array boundaries", expr: "$min(Account.Order.Product.UnitPrice)"},
+		{desc: "average across two array boundaries", expr: "$average(Account.Order.Product.UnitPrice)"},
+	}
+
+	rawData := json.RawMessage(pathBytesTestData)
+	var decoded any
+	if err := json.Unmarshal(rawData, &decoded); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			evalBytesMatchesEvalCase(t, tC.expr, rawData, decoded, (*gnata.Expression).IsFuncFastPath)
+		})
+	}
+}
+
+// TestEvalBytes_ArrayAutoMap_LiteralKeyWithSpecialChars guards against the
+// walker treating a field name as a gjson path expression instead of a
+// literal key. gjson.Result.Get interprets '.', '*', '?', '#', '|', '!',
+// brackets, and backslash as path syntax — a field literally named "a.b"
+// sitting alongside a nested {"a":{"b":...}} would resolve to the wrong
+// value (the nested one) if the walker ever called r.Get(step) with the raw
+// field name instead of doing a literal-key lookup.
+func TestEvalBytes_ArrayAutoMap_LiteralKeyWithSpecialChars(t *testing.T) {
+	rawData := json.RawMessage(`{"Items":[{"a.b": 99, "a": {"b": 1}}]}`)
+	var decoded any
+	if err := json.Unmarshal(rawData, &decoded); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	expr := `Items."a.b"`
+
+	e, err := gnata.Compile(expr)
+	if err != nil {
+		t.Fatalf("Compile(%q): %v", expr, err)
+	}
+	if !e.IsFastPath() {
+		t.Fatalf("Compile(%q): expected IsFastPath() == true so this exercises the walker", expr)
+	}
+
+	want, wantErr := e.Eval(context.Background(), decoded)
+	got, gotErr := e.EvalBytes(context.Background(), rawData)
+	if (wantErr == nil) != (gotErr == nil) {
+		t.Fatalf("EvalBytes err = %v, Eval err = %v", gotErr, wantErr)
+	}
+	// gnata.DeepEqual (JSONata equality), not reflect.DeepEqual: EvalBytes
+	// represents numbers as json.Number, Eval on already-decoded plain Go
+	// values sees float64 — both mean the same JSONata number.
+	if !gnata.DeepEqual(got, want) {
+		t.Fatalf("EvalBytes(%q) = %#v, want %#v (from Eval) — walker likely misread the literal key as a gjson path", expr, got, want)
+	}
+}
+
+func TestEvalBytes_ArrayAutoMap_FallsBackOnScalarStep(t *testing.T) {
+	// "Name" is a scalar, not an object or array — a further step past it
+	// must fall back to full evaluation and still report "undefined", not
+	// an incorrect fast-path value.
+	expr, err := gnata.Compile("Account.Name.Missing")
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	rawData := json.RawMessage(pathBytesTestData)
+	got, err := expr.EvalBytes(context.Background(), rawData)
+	if err != nil {
+		t.Fatalf("EvalBytes: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("EvalBytes(%q) = %#v, want nil (undefined)", "Account.Name.Missing", got)
+	}
+}


### PR DESCRIPTION
## What

`EvalBytes`/`EvalMap`'s gjson fast path only resolved a compiled expression when a single dotted gjson lookup succeeded directly — which never happens once the path crosses a JSON array, since gjson's dotted paths don't auto-map through arrays the way JSONata does. Every such expression silently fell back to a full `json.Unmarshal` + AST walk, even though the shape (pure path, comparison, `$exists`, `$contains`, numeric aggregate) was otherwise fast-path eligible.

- Adds a step-by-step `gjson.Result` walker (`path_bytes.go`) that auto-maps through arrays at each path step, mirroring `evalName`'s array-mapping semantics without ever decoding the document. Wired into the pure-path, comparison, `$exists`, `$contains`, and numeric aggregate (`$sum`/`$count`/`$min`/`$max`/`$average`) fast paths for both `EvalBytes` and `EvalMap`.
- The comparison rewrite bakes in two rules verified against the AST evaluator: `=`/`!=` do structural equality on the whole resolved value (a multi-element sequence is never equal to a scalar literal — no "any element matches"), and a genuinely undefined LHS makes both `=` and `!=` evaluate to `false`.
- Field-name lookups inside the walker use a literal-key scan (`ForEach` with an early exit) rather than `gjson.Result.Get`, since `Get` treats its argument as a full gjson path expression — a field literally named `"a.b"` would otherwise resolve to the wrong (nested) value.
- Adds `EvalBytesWithCustomFuncs` / `EvalBytesWithCustomEnvironmentAndVars`, mirroring the existing decoded-input `EvalWithCustomFuncs` / `EvalWithCustomEnvironmentAndVars`. Since the function fast path dispatches purely by source-text name with no reference to the caller's environment, it's split into a pure-path/comparison tier (`tryFastPathBytes`, always safe) and a function tier (`tryFuncFastBytes`, skipped for custom-environment callers, since a caller-registered function could otherwise be silently shadowed by a same-named builtin like `sum`).
- Shrinks the per-eval `Environment`'s allocation for the common ≤2-binding case: bindings are stored inline in a fixed-size array until they overflow into a lazily-allocated map. Fully internal — `Bind`/`Lookup`/`Clone`/`Range`/etc. keep their existing signatures and semantics.
- Bumps `npm/gnata-js` to 0.4.0 ahead of the v0.4.0 Go module release.

## Benchmarks

100-leaf two-array-boundary document, `EvalBytes`:

| | Before (full decode) | After (walker) |
|---|---|---|
| pure path / `$sum` / comparison / `$exists` / `$contains` | ~475µs / ~19,200 allocs | ~25-40µs / ~200-320 allocs |

Per-eval `Environment` allocation (`BenchmarkEval`, existing fixtures): 25-45% faster, 2-4 fewer allocations per call across all cases.

## Testing

- Full existing 1,200+ conformance suite (jsonata-js test corpus) passes unchanged.
- New differential tests assert `EvalBytes`/`EvalMap` match `Eval` byte-for-byte for every new code path, including edge cases (empty arrays, genuinely undefined paths, literal keys containing gjson-special characters, custom-function names that shadow a builtin).
- `go vet` and `golangci-lint run` are clean.