### PR TITLE
Add StreamEvaluator.EvalPreparsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ for i, result := range results {
 
 // Alternative: pre-decoded map input (avoids re-serialization)
 results, _ = se.EvalMap(ctx, fieldMap, schemaKey, indices)
+
+// Alternative: already-unmarshaled Go value (skips JSON decoding)
+results, _ = se.EvalPreparsed(ctx, eventMap, schemaKey, indices)
 ```
 
 ### Custom Function Registration
@@ -165,6 +168,7 @@ Hot Path (millions/day, lock-free)
 - **Lock-free reads** — `BoundedCache` publishes an `atomic.Pointer` snapshot on every write; reads scan the snapshot without acquiring a lock. Writes are serialised by a mutex.
 - **Selective unmarshal** — full-path expressions unmarshal only the subtrees they need (e.g., just the `items` array from a 10KB event), not the entire document.
 - **Pre-decoded map input** — `EvalMap` accepts `map[string]json.RawMessage` directly, skipping full-document serialization when the caller already has individually-encoded fields. Fast paths resolve top-level keys via O(1) map lookup.
+- **Pre-parsed Go values** — `EvalPreparsed` accepts `map[string]any`, `[]any`, or any other decoded value the AST evaluator already handles, skipping JSON decoding. GJSON fast paths are not used (they need raw bytes).
 - **Dynamic mutation** — `Replace`, `Remove`, and `Reset` methods allow modifying registered expressions at runtime with automatic cache invalidation.
 - **Observability** — implement `MetricsHook` to receive per-evaluation callbacks for cache hits/misses, eval latency, fast-path usage, and errors.
 
@@ -343,7 +347,7 @@ All standard regex features (character classes, quantifiers, alternation, groupi
 ```
 gnata/
 ├── gnata.go                     # Public API: Compile, Eval, EvalBytes, EvalBytesWithVars, EvalMap, EvalWithVars, CustomEnvironment, OrderedMap, JSONNull
-├── stream.go                    # StreamEvaluator, GroupPlan, EvalMany, EvalManyWithVars, EvalMap, MetricsHook
+├── stream.go                    # StreamEvaluator, GroupPlan, EvalMany, EvalManyWithVars, EvalMap, EvalPreparsed, MetricsHook
 ├── bounded_cache.go             # Lock-free FIFO ring-buffer plan cache
 ├── deep_equal.go                # JSONata-compatible deep equality
 ├── internal/

--- a/npm/package-lock.json
+++ b/npm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gnata-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gnata-js",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.8.0"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnata-js",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Browser JSONata via gnata WASM for backend parity, not a performance optimization",
   "license": "MIT",
   "repository": {

--- a/stream.go
+++ b/stream.go
@@ -244,6 +244,21 @@ func (se *StreamEvaluator) EvalMap(
 	return se.evalInternal(ctx, nil, nil, data, nil, schemaKey, exprIndices)
 }
 
+// EvalPreparsed evaluates the specified expressions against an already-decoded
+// JSON-like Go value (for example map[string]any or []any).
+//   - data: pre-parsed input value. Skips the JSON decoding step used by EvalMany.
+//   - schemaKey: external key identifying the event schema. On first encounter, builds
+//     and caches a GroupPlan. Subsequent calls are lock-free. Pass "" to disable caching.
+//   - exprIndices: which compiled expressions to evaluate.
+//
+// Returns results[i] = evaluation of expressions[exprIndices[i]], or nil for undefined.
+// GJSON fast paths require raw JSON bytes and are not used; evaluation uses the AST.
+func (se *StreamEvaluator) EvalPreparsed(
+	ctx context.Context, data any, schemaKey string, exprIndices []int,
+) ([]any, error) {
+	return se.evalInternal(ctx, nil, data, nil, nil, schemaKey, exprIndices)
+}
+
 func (se *StreamEvaluator) evalInternal(
 	ctx context.Context,
 	data json.RawMessage,
@@ -337,6 +352,11 @@ func (b *evalBatch) evalSingleExpr(ctx context.Context, i, idx int, expr *Expres
 // Returns (result, true, nil) on success, (nil, false, nil) to signal fallback,
 // or (nil, true, err) on error.
 func (b *evalBatch) tryFastPaths(i, idx int, start time.Time) (result any, done bool, err error) {
+	// $exists treats a failed byte walk as handled false; skip when there are no bytes.
+	if b.data == nil && b.mapData == nil {
+		return nil, false, nil
+	}
+
 	if b.plan != nil && i < len(b.plan.ExprFastPath) && b.plan.ExprFastPath[i] && b.plan.FastPaths[i] != "" {
 		r := resolveGjsonPath(b.data, b.mapData, b.plan.FastPaths[i])
 		if r.Exists() {

--- a/stream_test.go
+++ b/stream_test.go
@@ -387,13 +387,33 @@ func (h *testMetricsHook) OnCacheHit(_ string)  { h.hits++ }
 func (h *testMetricsHook) OnCacheMiss(_ string) { h.misses++ }
 func (h *testMetricsHook) OnEviction()          { h.evictions++ }
 
-// TestStreamEvaluator_EvalMap verifies that EvalMap produces identical results
-// to EvalMany for the same data and expressions.
-func TestStreamEvaluator_EvalMap(t *testing.T) {
-	rawData := json.RawMessage(streamTestData)
+func assertEvalManyParity(t *testing.T, expr string, want any, eval func(*gnata.StreamEvaluator, int) (any, error)) {
+	t.Helper()
+	se := gnata.NewStreamEvaluator(nil)
+	idx, err := se.Compile(expr)
+	if err != nil {
+		t.Fatalf("Compile(%q): %v", expr, err)
+	}
 
+	many, err := se.EvalMany(context.Background(), json.RawMessage(streamTestData), "", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalMany: %v", err)
+	}
+	got, err := eval(se, idx)
+	if err != nil {
+		t.Fatalf("eval: %v", err)
+	}
+	if !gnata.DeepEqual(many[0], got) {
+		t.Errorf("EvalMany=%v (%T), other=%v (%T)", many[0], many[0], got, got)
+	}
+	if !gnata.DeepEqual(got, want) {
+		t.Errorf("want %v (%T), got %v (%T)", want, want, got, got)
+	}
+}
+
+func TestStreamEvaluator_EvalMap(t *testing.T) {
 	var dataMap map[string]json.RawMessage
-	if err := json.Unmarshal(rawData, &dataMap); err != nil {
+	if err := json.Unmarshal(json.RawMessage(streamTestData), &dataMap); err != nil {
 		t.Fatalf("unmarshal to map: %v", err)
 	}
 
@@ -412,31 +432,13 @@ func TestStreamEvaluator_EvalMap(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			se := gnata.NewStreamEvaluator(nil)
-			idx, err := se.Compile(tc.expr)
-			if err != nil {
-				t.Fatalf("Compile(%q): %v", tc.expr, err)
-			}
-
-			evalManyResult, err := se.EvalMany(context.Background(), rawData, "", []int{idx})
-			if err != nil {
-				t.Fatalf("EvalMany: %v", err)
-			}
-
-			evalMapResult, err := se.EvalMap(context.Background(), dataMap, "", []int{idx})
-			if err != nil {
-				t.Fatalf("EvalMap: %v", err)
-			}
-
-			if !gnata.DeepEqual(evalManyResult[0], evalMapResult[0]) {
-				t.Errorf("EvalMany=%v (%T), EvalMap=%v (%T)",
-					evalManyResult[0], evalManyResult[0],
-					evalMapResult[0], evalMapResult[0])
-			}
-			if !gnata.DeepEqual(evalMapResult[0], tc.want) {
-				t.Errorf("want %v (%T), got %v (%T)",
-					tc.want, tc.want, evalMapResult[0], evalMapResult[0])
-			}
+			assertEvalManyParity(t, tc.expr, tc.want, func(se *gnata.StreamEvaluator, idx int) (any, error) {
+				results, err := se.EvalMap(context.Background(), dataMap, "", []int{idx})
+				if err != nil {
+					return nil, err
+				}
+				return results[0], nil
+			})
 		})
 	}
 }
@@ -543,6 +545,140 @@ func TestStreamEvaluator_EvalMap_FastPaths(t *testing.T) {
 				t.Errorf("expected fast path for %q but MetricsHook reported 0 fast paths", tc.expr)
 			}
 		})
+	}
+}
+
+func streamTestMap(t *testing.T) map[string]any {
+	t.Helper()
+	var data map[string]any
+	if err := json.Unmarshal([]byte(streamTestData), &data); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	return data
+}
+
+func TestStreamEvaluator_EvalPreparsed(t *testing.T) {
+	data := streamTestMap(t)
+
+	tests := []struct {
+		name string
+		expr string
+		want any
+	}{
+		{"path lookup", `data.action`, "grant-access"},
+		{"comparison", `data.user_type = 2`, true},
+		{"boolean field", `metadata.is_admin`, true},
+		{"greater than", `data.user_type > 1`, true},
+		{"nested path", `data.user_type`, float64(2)},
+		{"and expression", `data.user_type = 2 and metadata.is_admin = true`, true},
+		{"exists present", `$exists(data.action)`, true},
+		{"exists missing", `$exists(nonexistent.field)`, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assertEvalManyParity(t, tc.expr, tc.want, func(se *gnata.StreamEvaluator, idx int) (any, error) {
+				results, err := se.EvalPreparsed(context.Background(), data, "", []int{idx})
+				if err != nil {
+					return nil, err
+				}
+				return results[0], nil
+			})
+		})
+	}
+}
+
+func TestStreamEvaluator_EvalPreparsed_MultipleExprs(t *testing.T) {
+	data := streamTestMap(t)
+
+	se := gnata.NewStreamEvaluator(nil)
+	idx0, _ := se.Compile(`data.action`)
+	idx1, _ := se.Compile(`data.user_type = 2`)
+	idx2, _ := se.Compile(`$exists(data.action)`)
+
+	results, err := se.EvalPreparsed(context.Background(), data, "schema", []int{idx0, idx1, idx2})
+	if err != nil {
+		t.Fatalf("EvalPreparsed: %v", err)
+	}
+
+	if results[0] != "grant-access" {
+		t.Errorf("result[0]: want grant-access, got %v", results[0])
+	}
+	if results[1] != true {
+		t.Errorf("result[1]: want true, got %v", results[1])
+	}
+	if results[2] != true {
+		t.Errorf("result[2]: want true, got %v", results[2])
+	}
+}
+
+func TestStreamEvaluator_EvalPreparsed_NilAndEmpty(t *testing.T) {
+	se := gnata.NewStreamEvaluator(nil)
+	idx, _ := se.Compile(`foo`)
+
+	results, err := se.EvalPreparsed(context.Background(), nil, "", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalPreparsed(nil): %v", err)
+	}
+	if results[0] != nil {
+		t.Errorf("nil data: want nil result, got %v", results[0])
+	}
+
+	results, err = se.EvalPreparsed(context.Background(), map[string]any{}, "", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalPreparsed(empty): %v", err)
+	}
+	if results[0] != nil {
+		t.Errorf("empty map: want nil result, got %v", results[0])
+	}
+
+	results, err = se.EvalPreparsed(context.Background(), map[string]any{}, "", nil)
+	if err != nil {
+		t.Fatalf("EvalPreparsed(no indices): %v", err)
+	}
+	if results != nil {
+		t.Errorf("no indices: want nil results, got %v", results)
+	}
+}
+
+func TestStreamEvaluator_EvalPreparsed_SkipsFastPaths(t *testing.T) {
+	data := streamTestMap(t)
+	hook := &testMetricsHook{}
+	se := gnata.NewStreamEvaluator(nil, gnata.WithMetricsHook(hook))
+	idx, err := se.Compile(`$exists(data.action)`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	results, err := se.EvalPreparsed(context.Background(), data, "s", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalPreparsed: %v", err)
+	}
+	if results[0] != true {
+		t.Errorf("want true, got %v", results[0])
+	}
+	if hook.fastPaths != 0 {
+		t.Errorf("EvalPreparsed must not use GJSON fast paths, got %d", hook.fastPaths)
+	}
+}
+
+func TestStreamEvaluator_EvalPreparsed_CustomFuncs(t *testing.T) {
+	se := gnata.NewStreamEvaluator(nil, gnata.WithCustomFunctions(map[string]gnata.CustomFunc{
+		"greet": func(args []any, _ any) (any, error) {
+			return "hello " + args[0].(string), nil
+		},
+	}))
+	idx, err := se.Compile(`$greet(name)`)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	results, err := se.EvalPreparsed(context.Background(), map[string]any{"name": "world"}, "", []int{idx})
+	if err != nil {
+		t.Fatalf("EvalPreparsed: %v", err)
+	}
+	if results[0] != "hello world" {
+		t.Errorf("want %q, got %v", "hello world", results[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `StreamEvaluator.EvalPreparsed` to evaluate compiled expressions against already-decoded Go values (`map[string]any`, `[]any`, scalars) without a JSON decode step.
- Skip GJSON fast paths when no raw bytes are present so `$exists` cannot return a false negative.
- Bump `gnata-js` to 0.4.1 ahead of the v0.4.1 Go module release.

Closes #25

## Test plan
- [x] `go test .` including EvalMany parity, `$exists` present/missing, nil/empty input, and custom functions
- [x] `golangci-lint run`