### PR TITLE
ci: publish statement coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,12 @@ jobs:
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - run: go test -race -count=1 ./...
+      - name: Test
+        run: |
+          go test -race -count=1 -coverprofile=coverage.out -coverpkg=./... ./...
+          go tool cover -func=coverage.out
+          total=$(go tool cover -func=coverage.out | awk '/^total:/{gsub(/%/,"",$NF); print $NF}')
+          awk -v t="$total" 'BEGIN { if (t+0 < 80) { printf "coverage %.1f%% is below 80%%\n", t; exit 1 } }'
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.wasm
 .secret
 .DS_Store
+coverage.out
 
 # npm package build artifacts
 npm/dist/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 <p align="center">
   <a href="https://github.com/RecoLabs/gnata/actions/workflows/ci.yml"><img src="https://github.com/RecoLabs/gnata/actions/workflows/ci.yml/badge.svg" alt="CI" /></a>
+  <a href="https://github.com/RecoLabs/gnata/actions/workflows/ci.yml"><img src="https://img.shields.io/badge/coverage-82.7%25-brightgreen" alt="Coverage" /></a>
   <a href="https://pkg.go.dev/github.com/recolabs/gnata"><img src="https://pkg.go.dev/badge/github.com/recolabs/gnata.svg" alt="Go Reference" /></a>
   <a href="https://github.com/RecoLabs/gnata/blob/main/go.mod"><img src="https://img.shields.io/github/go-mod/go-version/RecoLabs/gnata" alt="Go version" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="MIT License" /></a>


### PR DESCRIPTION
## Summary
- Collect a cover profile in the test job, print `go tool cover -func`, and fail if statement coverage drops below 80%.
- Add a README coverage badge (82.7%, matching current `main`) that links to the CI workflow.
- Ignore `coverage.out` so profiles stay local to the runner.

## Test plan
- [ ] CI test job is green and the log includes a `total: (statements)` line at or above 80%.
- [ ] README coverage badge renders next to the existing CI badge.

This PR was prepared with Cursor.